### PR TITLE
Update dataschema version checking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pressly/goose/v3 v3.20.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.17.1
+	golang.org/x/mod v0.18.0
 	golang.org/x/text v0.16.0
 	golang.org/x/tools v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -76,7 +77,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
-	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240213162025-012b6fc9bca9 // indirect

--- a/pkg/vss/convert/convert.go
+++ b/pkg/vss/convert/convert.go
@@ -6,15 +6,16 @@ import (
 
 	"github.com/DIMO-Network/model-garage/pkg/vss"
 	"github.com/tidwall/gjson"
+	"golang.org/x/mod/semver"
 )
 
 const (
 	// StatusV1 is the version string for payloads with the version 1.0 schema.
-	StatusV1 = "1.0"
+	StatusV1 = "v1.0.0"
 	// StatusV1Converted is the version string for payloads that have been converted to the 1.0 schema.
-	StatusV1Converted = "1.1"
+	StatusV1Converted = "v1.1.0"
 	// StatusV2 is the version string for payloads with the version 2.0 schema.
-	StatusV2 = "2.0"
+	StatusV2 = "v2.0.0"
 )
 
 // SignalsFromPayload extracts signals from a payload.
@@ -22,9 +23,11 @@ const (
 func SignalsFromPayload(ctx context.Context, tokenGetter TokenIDGetter, jsonData []byte) ([]vss.Signal, error) {
 	version := GetSchemaVersion(jsonData)
 	switch {
-	case version == StatusV1 || version == StatusV1Converted:
+	case version == "": // empty string to support legacy status payloads without dataschema
+		fallthrough
+	case semver.Compare(StatusV1, version) == 0 || semver.Compare(StatusV1Converted, version) == 0:
 		return SignalsFromV1Payload(ctx, tokenGetter, jsonData)
-	case version == StatusV2:
+	case semver.Compare(StatusV2, version) == 0:
 		return SignalsFromV2Payload(jsonData)
 	default:
 		return nil, VersionError{Version: version}
@@ -34,12 +37,10 @@ func SignalsFromPayload(ctx context.Context, tokenGetter TokenIDGetter, jsonData
 // GetSchemaVersion returns the version string of the schema used in the payload.
 func GetSchemaVersion(jsonData []byte) string {
 	dataSchema := gjson.GetBytes(jsonData, "dataschema")
-	if dataSchema.Exists() {
-		// get version string at the end of the URI
-		// Ex. dimo.zone.status/v1.1
-		schemaString := dataSchema.String()
-		version := schemaString[strings.LastIndex(schemaString, "/")+1:]
-		return strings.TrimPrefix(version, "v")
+	if !dataSchema.Exists() {
+		return ""
 	}
-	return gjson.GetBytes(jsonData, "specversion").String()
+	schemaString := dataSchema.String()
+	version := schemaString[strings.LastIndex(schemaString, "/")+1:]
+	return version
 }

--- a/pkg/vss/convert/convert_test.go
+++ b/pkg/vss/convert/convert_test.go
@@ -1,0 +1,168 @@
+package convert_test
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/DIMO-Network/model-garage/pkg/vss"
+	"github.com/DIMO-Network/model-garage/pkg/vss/convert"
+)
+
+func TestVersionComparison(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		jsonData    []byte
+		expected    []vss.Signal
+		expectedErr error
+	}{
+		{
+			name:     "Version v2.0",
+			jsonData: []byte(`{"dataschema":"dimo.zone.status/v2.0", "specversion":"1.0", "vehicleTokenId": 1, "source": "source1", "data": {"vehicle": {"signals": [{"name": "speed", "timestamp": 1734957240000, "value": 1.0}]}}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "Version v2 no trailing slash",
+			jsonData: []byte(`{"dataschema":"v2", "specversion":"1.0", "vehicleTokenId": 1, "source": "source1", "data": {"vehicle": {"signals": [{"name": "speed", "timestamp": 1734957240000, "value": 1.0}]}}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "Version v1.0",
+			jsonData: []byte(`{"dataschema":"dimo.zone.status/v1.0", "time": "2024-12-23T12:34:00Z", "source": "source1", "subject": "1" "data"{"speed": 1.0}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "Version v1",
+			jsonData: []byte(`{"dataschema":"dimo.zone.status/v1", "time": "2024-12-23T12:34:00Z", "source": "source1", "subject": "1" "data"{"speed": 1.0}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "Version v1.0.0",
+			jsonData: []byte(`{"dataschema":"dimo.zone.status/v1.0.0", "time": "2024-12-23T12:34:00Z", "source": "source1", "subject": "1" "data"{"speed": 1.0}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "Version v1.1",
+			jsonData: []byte(`{"dataschema":"dimo.zone.status/v1.1", "time": "2024-12-23T12:34:00Z", "source": "source1", "subject": "1" "data"{"speed": 1.0}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "Version v1.1.0",
+			jsonData: []byte(`{"dataschema":"dimo.zone.status/v1.1.0", "time": "2024-12-23T12:34:00Z", "source": "source1", "subject": "1" "data"{"speed": 1.0}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:     "No dataschema",
+			jsonData: []byte(`{"specversion":"1.0", "time": "2024-12-23T12:34:00Z", "source": "source1", "subject": "1" "data"{"speed": 1.0}}`),
+			expected: []vss.Signal{
+				{
+					TokenID:     1,
+					Timestamp:   time.Date(2024, 12, 23, 12, 34, 0, 0, time.UTC),
+					Name:        vss.FieldSpeed,
+					Source:      "source1",
+					ValueNumber: 1.0,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "Unknown Version",
+			jsonData:    []byte(`{"dataschema": "dimo.zone.status/v3.0"}`),
+			expected:    nil,
+			expectedErr: convert.VersionError{Version: "v3.0"},
+		},
+		{
+			name:        "Invalid Version missing v",
+			jsonData:    []byte(`{"dataschema": "dimo.zone.status/1.0"}`),
+			expected:    nil,
+			expectedErr: convert.VersionError{Version: "1.0"},
+		},
+	}
+
+	tokenGetter := &testGetter{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			signals, err := convert.SignalsFromPayload(context.Background(), tokenGetter, test.jsonData)
+			if !reflect.DeepEqual(signals, test.expected) {
+				t.Errorf("Unexpected signals. Expected: %v, Got: %v", test.expected, signals)
+			}
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Unexpected error. Expected: %v, Got: %v", test.expectedErr, err)
+			}
+		})
+	}
+}
+
+type testGetter struct{}
+
+func (t *testGetter) TokenIDFromSubject(ctx context.Context, subject string) (uint32, error) {
+	id, err := strconv.Atoi(subject)
+	return uint32(id), err
+}

--- a/pkg/vss/convert/payloadv1_test.go
+++ b/pkg/vss/convert/payloadv1_test.go
@@ -28,6 +28,7 @@ var (
 	fullInputJSON = `{
 		"id": "randomIDnumber",
 		"specversion": "1.0",
+		"dataschema": "test.status/v1",
 		"source": "dimo/integration/123",
 		"subject": "Vehicle123",
 		"time": "2022-01-01T12:34:56Z",

--- a/pkg/vss/convert/payloadv2_test.go
+++ b/pkg/vss/convert/payloadv2_test.go
@@ -21,7 +21,8 @@ func TestFullFromV2DataConversion(t *testing.T) {
 var fullV2InputJSON = `{
     "id": "2fHbFXPWzrVActDb7WqWCfqeiYe",
     "source": "dimo/integration/123",
-    "specversion": "2.0",
+    "specversion": "1.0",
+    "dataschema": "testschema/v2.0",
     "subject": "0x98D78d711C0ec544F6fb5d54fcf6559CF41546a9",
     "time": "2024-04-18T17:20:46.436008782Z",
     "type": "com.dimo.device.status",


### PR DESCRIPTION
* Update version comparison to use semver package
* Remove specversion backup check
* Allow missing dataschema field to be treated as v1.0.0
   (This supports legacy status payloads)