### PR TITLE
Add handling for v2 payload translations.

### DIFF
--- a/pkg/schema/spec/definitions.yaml
+++ b/pkg/schema/spec/definitions.yaml
@@ -167,7 +167,7 @@
       isArray: false
   requiredPrivileges:
     - VEHICLE_NON_LOCATION_DATA
-- vspecName: Vehicle.Powertrain.FuelSystem.AbsoluteLevel
+- vspecName: Vehicle.Powertrain.FuelSystem.RelativeLevel
   goType: ""
   conversions:
     - originalName: fuelLevel # dataschema v2

--- a/pkg/schema/spec/definitions.yaml
+++ b/pkg/schema/spec/definitions.yaml
@@ -84,7 +84,10 @@
 - vspecName: Vehicle.Exterior.AirTemperature
   goType: ""
   conversions:
-    - originalName: ambientTemp
+    - originalName: ambientAirTemp # dataschema v2
+      originalType: float64
+      isArray: false
+    - originalName: ambientTemp # dataschema v1
       originalType: float64
       isArray: false
   requiredPrivileges:
@@ -148,7 +151,10 @@
 - vspecName: Vehicle.Powertrain.CombustionEngine.Speed
   goType: ""
   conversions:
-    - originalName: engineSpeed
+    - originalName: rpm # dataschema v2
+      originalType: float64
+      isArray: false
+    - originalName: engineSpeed # dataschema v1
       originalType: float64
       isArray: false
   requiredPrivileges:
@@ -164,7 +170,10 @@
 - vspecName: Vehicle.Powertrain.FuelSystem.AbsoluteLevel
   goType: ""
   conversions:
-    - originalName: fuelPercentRemaining
+    - originalName: fuelLevel # dataschema v2
+      originalType: float64
+      isArray: false
+    - originalName: fuelPercentRemaining # dataschema v1
       originalType: float64
       isArray: false
   requiredPrivileges:
@@ -245,7 +254,10 @@
 - vspecName: Vehicle.Speed
   goType: ""
   conversions:
-    - originalName: speed
+    - originalName: vehicleSpeed # dataschema v2
+      originalType: float64
+      isArray: false
+    - originalName: speed # dataschema v1
       originalType: float64
       isArray: false
   requiredPrivileges:
@@ -301,7 +313,10 @@
 - vspecName: Vehicle.DIMO.Aftermarket.WPAState
   goType: ""
   conversions:
-    - originalName: wpa_state
+    - originalName: wpa_state # dataschema v2
+      originalType: string
+      isArray: false
+    - originalName: wifi.wpaState # dataschema v1
       originalType: string
       isArray: false
   requiredPrivileges:
@@ -309,7 +324,10 @@
 - vspecName: Vehicle.DIMO.Aftermarket.SSID
   goType: ""
   conversions:
-    - originalName: ssid
+    - originalName: ssid # dataschema v2
+      originalType: string
+      isArray: false
+    - originalName: wifi.ssid # dataschema v1
       originalType: string
       isArray: false
   requiredPrivileges:

--- a/pkg/vss/convert/payloadv1_test.go
+++ b/pkg/vss/convert/payloadv1_test.go
@@ -72,7 +72,7 @@ var (
 			"fuelPercentRemaining": 0.6,
 			"fuelType": "Gasoline",
 			"range": 300.0,
-			"chargeLimit": 80.0,
+			"chargeLimit": 0.8,
 			"charging": true,
 			"batteryCapacity": 60.0,
 			"soc": 0.7,

--- a/pkg/vss/convert/payloadv1_test.go
+++ b/pkg/vss/convert/payloadv1_test.go
@@ -102,7 +102,7 @@ var (
 		{TokenID: 123, Timestamp: ts, Name: "powertrainCombustionEngineEngineOilLevel", ValueString: "CRITICALLY_LOW", Source: "dimo/integration/123"},
 		{TokenID: 123, Timestamp: ts, Name: "powertrainCombustionEngineSpeed", ValueNumber: 3000, Source: "dimo/integration/123"},
 		{TokenID: 123, Timestamp: ts, Name: "powertrainCombustionEngineTPS", ValueNumber: 50, Source: "dimo/integration/123"},
-		{TokenID: 123, Timestamp: ts, Name: "powertrainFuelSystemAbsoluteLevel", ValueNumber: 60, Source: "dimo/integration/123"},
+		{TokenID: 123, Timestamp: ts, Name: "powertrainFuelSystemRelativeLevel", ValueNumber: 60, Source: "dimo/integration/123"},
 		{TokenID: 123, Timestamp: ts, Name: "powertrainFuelSystemSupportedFuelTypes", ValueString: "GASOLINE", Source: "dimo/integration/123"},
 		{TokenID: 123, Timestamp: ts, Name: "powertrainRange", ValueNumber: 300, Source: "dimo/integration/123"},
 		{TokenID: 123, Timestamp: ts, Name: "powertrainType", ValueString: "COMBUSTION", Source: "dimo/integration/123"},

--- a/pkg/vss/convert/payloadv1_test.go
+++ b/pkg/vss/convert/payloadv1_test.go
@@ -1,7 +1,9 @@
 package convert_test
 
 import (
+	"cmp"
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -21,7 +23,15 @@ func TestFullFromDataConversion(t *testing.T) {
 	getter := &tokenGetter{}
 	actualSignals, err := convert.SignalsFromPayload(context.Background(), getter, []byte(fullInputJSON))
 	require.NoErrorf(t, err, "error converting full input data: %v", err)
-	require.ElementsMatchf(t, expectedSignals, actualSignals, "converted vehicle does not match expected vehicle")
+
+	// sort the signals so diffs are easier to read
+	sortFunc := func(a, b vss.Signal) int {
+		return cmp.Compare(a.Name, b.Name)
+	}
+	slices.SortFunc(expectedSignals, sortFunc)
+	slices.SortFunc(actualSignals, sortFunc)
+
+	require.Equal(t, expectedSignals, actualSignals, "converted vehicle does not match expected vehicle")
 }
 
 var (
@@ -52,14 +62,14 @@ var (
 			"ambientTemp": 25.0,
 			"batteryVoltage": 12.5,
 			"barometricPressure": 1013.25,
-			"engineLoad": 75.0,
+			"engineLoad": 0.75,
 			"intakeTemp": 30.0,
 			"runTime": 1200.0,
 			"coolantTemp": 90.0,
 			"oil": 0.10,
 			"engineSpeed": 3000.0,
-			"throttlePosition": 50.0,
-			"fuelPercentRemaining": 60.0,
+			"throttlePosition": 0.50,
+			"fuelPercentRemaining": 0.6,
 			"fuelType": "Gasoline",
 			"range": 300.0,
 			"chargeLimit": 80.0,

--- a/pkg/vss/convert/payloadv1_test.go
+++ b/pkg/vss/convert/payloadv1_test.go
@@ -75,7 +75,7 @@ var (
 			"chargeLimit": 80.0,
 			"charging": true,
 			"batteryCapacity": 60.0,
-			"soc": 70.0,
+			"soc": 0.7,
 			"odometer": 50000.0,
 			"speed": 60.0,
 			"make": "Toyota",

--- a/pkg/vss/convert/payloadv2_test.go
+++ b/pkg/vss/convert/payloadv2_test.go
@@ -119,7 +119,22 @@ var fullV2InputJSON = `{
                     "timestamp": 1713460846435,
                     "name": "ssid",
                     "value": "foo"
-                }
+                },
+                {
+                    "timestamp": 1713460846435,
+                    "name": "vehicleSpeed",
+                    "value": 39
+                },
+                {
+                    "timestamp": 1713460846435,
+                    "name": "rpm",
+                    "value": 2000
+                },
+                {
+                    "timestamp": 1713460846435,
+                    "name": "fuelLevel",
+                    "value": 50
+                },
             ]
         }
     },
@@ -144,4 +159,7 @@ var expectedV2Signals = []vss.Signal{
 	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "dimoAftermarketNSAT", ValueNumber: 6, ValueString: "", Source: "dimo/integration/123"},
 	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "dimoAftermarketWPAState", ValueNumber: 0, ValueString: "COMPLETED", Source: "dimo/integration/123"},
 	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "dimoAftermarketSSID", ValueNumber: 0, ValueString: "foo", Source: "dimo/integration/123"},
+	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "speed", ValueNumber: 39, ValueString: "", Source: "dimo/integration/123"},
+	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "powertrainCombustionEngineSpeed", ValueNumber: 2000, ValueString: "", Source: "dimo/integration/123"},
+	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "powertrainFuelSystemAbsoluteLevel", ValueNumber: 50, ValueString: "", Source: "dimo/integration/123"},
 }

--- a/pkg/vss/convert/payloadv2_test.go
+++ b/pkg/vss/convert/payloadv2_test.go
@@ -161,5 +161,5 @@ var expectedV2Signals = []vss.Signal{
 	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "dimoAftermarketSSID", ValueNumber: 0, ValueString: "foo", Source: "dimo/integration/123"},
 	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "speed", ValueNumber: 39, ValueString: "", Source: "dimo/integration/123"},
 	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "powertrainCombustionEngineSpeed", ValueNumber: 2000, ValueString: "", Source: "dimo/integration/123"},
-	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "powertrainFuelSystemAbsoluteLevel", ValueNumber: 50, ValueString: "", Source: "dimo/integration/123"},
+	{TokenID: tokenID, Timestamp: time.Date(2024, time.April, 18, 17, 20, 46, 435000000, time.UTC), Name: "powertrainFuelSystemRelativeLevel", ValueNumber: 50, ValueString: "", Source: "dimo/integration/123"},
 }

--- a/pkg/vss/convert/vehicle-convert-funcs_gen.go
+++ b/pkg/vss/convert/vehicle-convert-funcs_gen.go
@@ -3,9 +3,9 @@ package convert
 
 import (
 	"fmt"
+	"math"
 	"time"
 
-	"github.com/tidwall/gjson"
 	"golang.org/x/mod/semver"
 )
 
@@ -98,9 +98,21 @@ func ToDIMOAftermarketSSID0(originalDoc []byte, val string) (string, error) {
 	return val, nil
 }
 
+// ToDIMOAftermarketSSID1 converts data from field 'wifi.ssid' of type string to 'Vehicle.DIMO.Aftermarket.SSID' of type string.
+// Vehicle.DIMO.Aftermarket.SSID: Service Set Ientifier for the wifi.
+func ToDIMOAftermarketSSID1(originalDoc []byte, val string) (string, error) {
+	return val, nil
+}
+
 // ToDIMOAftermarketWPAState0 converts data from field 'wpa_state' of type string to 'Vehicle.DIMO.Aftermarket.WPAState' of type string.
 // Vehicle.DIMO.Aftermarket.WPAState: Indicate the current wpa state for the devices wifi
 func ToDIMOAftermarketWPAState0(originalDoc []byte, val string) (string, error) {
+	return val, nil
+}
+
+// ToDIMOAftermarketWPAState1 converts data from field 'wifi.wpaState' of type string to 'Vehicle.DIMO.Aftermarket.WPAState' of type string.
+// Vehicle.DIMO.Aftermarket.WPAState: Indicate the current wpa state for the devices wifi
+func ToDIMOAftermarketWPAState1(originalDoc []byte, val string) (string, error) {
 	return val, nil
 }
 
@@ -113,10 +125,17 @@ func ToDIMOIsLocationRedacted0(originalDoc []byte, val bool) (float64, error) {
 	return 0, nil
 }
 
-// ToExteriorAirTemperature0 converts data from field 'ambientTemp' of type float64 to 'Vehicle.Exterior.AirTemperature' of type float64.
+// ToExteriorAirTemperature0 converts data from field 'ambientAirTemp' of type float64 to 'Vehicle.Exterior.AirTemperature' of type float64.
 // Vehicle.Exterior.AirTemperature: Air temperature outside the vehicle.
 // Unit: 'celsius'
 func ToExteriorAirTemperature0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToExteriorAirTemperature1 converts data from field 'ambientTemp' of type float64 to 'Vehicle.Exterior.AirTemperature' of type float64.
+// Vehicle.Exterior.AirTemperature: Air temperature outside the vehicle.
+// Unit: 'celsius'
+func ToExteriorAirTemperature1(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 
@@ -138,8 +157,8 @@ func ToOBDBarometricPressure0(originalDoc []byte, val float64) (float64, error) 
 // Vehicle.OBD.EngineLoad: PID 04 - Engine load in percent - 0 = no load, 100 = full load
 // Unit: 'percent'
 func ToOBDEngineLoad0(originalDoc []byte, val float64) (float64, error) {
-	version := gjson.GetBytes(originalDoc, "dataschema").String()
-	if semver.Compare("v1", version) == 0 || semver.Compare(StatusV1Converted, version) == 0 {
+	version := GetSchemaVersion(originalDoc)
+	if semver.Compare(StatusV1, version) == 0 || semver.Compare(StatusV1Converted, version) == 0 {
 		return val * 100, nil
 	}
 	return val, nil
@@ -190,10 +209,17 @@ func ToPowertrainCombustionEngineMAF0(originalDoc []byte, val float64) (float64,
 	return val, nil
 }
 
-// ToPowertrainCombustionEngineSpeed0 converts data from field 'engineSpeed' of type float64 to 'Vehicle.Powertrain.CombustionEngine.Speed' of type float64.
+// ToPowertrainCombustionEngineSpeed0 converts data from field 'rpm' of type float64 to 'Vehicle.Powertrain.CombustionEngine.Speed' of type float64.
 // Vehicle.Powertrain.CombustionEngine.Speed: Engine speed measured as rotations per minute.
 // Unit: 'rpm'
 func ToPowertrainCombustionEngineSpeed0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToPowertrainCombustionEngineSpeed1 converts data from field 'engineSpeed' of type float64 to 'Vehicle.Powertrain.CombustionEngine.Speed' of type float64.
+// Vehicle.Powertrain.CombustionEngine.Speed: Engine speed measured as rotations per minute.
+// Unit: 'rpm'
+func ToPowertrainCombustionEngineSpeed1(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 
@@ -201,14 +227,25 @@ func ToPowertrainCombustionEngineSpeed0(originalDoc []byte, val float64) (float6
 // Vehicle.Powertrain.CombustionEngine.TPS: Current throttle position.
 // Unit: 'percent'  Max: '100'
 func ToPowertrainCombustionEngineTPS0(originalDoc []byte, val float64) (float64, error) {
+	schemaVersion := GetSchemaVersion(originalDoc)
+	if semver.Compare(StatusV1, schemaVersion) == 0 || semver.Compare(StatusV1Converted, schemaVersion) == 0 {
+		return val * 100, nil
+	}
 	return val, nil
 }
 
-// ToPowertrainFuelSystemAbsoluteLevel0 converts data from field 'fuelPercentRemaining' of type float64 to 'Vehicle.Powertrain.FuelSystem.AbsoluteLevel' of type float64.
+// ToPowertrainFuelSystemAbsoluteLevel0 converts data from field 'fuelLevel' of type float64 to 'Vehicle.Powertrain.FuelSystem.AbsoluteLevel' of type float64.
 // Vehicle.Powertrain.FuelSystem.AbsoluteLevel: Current available fuel in the fuel tank expressed in liters.
 // Unit: 'l'
 func ToPowertrainFuelSystemAbsoluteLevel0(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
+}
+
+// ToPowertrainFuelSystemAbsoluteLevel1 converts data from field 'fuelPercentRemaining' of type float64 to 'Vehicle.Powertrain.FuelSystem.AbsoluteLevel' of type float64.
+// Vehicle.Powertrain.FuelSystem.AbsoluteLevel: Current available fuel in the fuel tank expressed in liters.
+// Unit: 'l'
+func ToPowertrainFuelSystemAbsoluteLevel1(originalDoc []byte, val float64) (float64, error) {
+	return val * 100, nil
 }
 
 // ToPowertrainFuelSystemSupportedFuelTypes0 converts data from field 'fuelType' of type string to 'Vehicle.Powertrain.FuelSystem.SupportedFuelTypes' of type string.
@@ -277,6 +314,12 @@ func ToPowertrainTractionBatteryStateOfChargeCurrent0(originalDoc []byte, val fl
 // Vehicle.Powertrain.Transmission.TravelledDistance: Odometer reading, total distance travelled during the lifetime of the transmission.
 // Unit: 'km'
 func ToPowertrainTransmissionTravelledDistance0(originalDoc []byte, val float64) (float64, error) {
+	if val > 999999 {
+		// if the value is absurdly high, it is likely in meters, convert to kilometers
+		// TODO: find a reliable way to determine if the value is in meters
+		const metersToKilometers = 1000
+		return math.Round(val / metersToKilometers), nil
+	}
 	return val, nil
 }
 
@@ -291,10 +334,17 @@ func ToPowertrainType0(originalDoc []byte, val string) (string, error) {
 	return "COMBUSTION", nil
 }
 
-// ToSpeed0 converts data from field 'speed' of type float64 to 'Vehicle.Speed' of type float64.
+// ToSpeed0 converts data from field 'vehicleSpeed' of type float64 to 'Vehicle.Speed' of type float64.
 // Vehicle.Speed: Vehicle speed.
 // Unit: 'km/h'
 func ToSpeed0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToSpeed1 converts data from field 'speed' of type float64 to 'Vehicle.Speed' of type float64.
+// Vehicle.Speed: Vehicle speed.
+// Unit: 'km/h'
+func ToSpeed1(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 

--- a/pkg/vss/convert/vehicle-convert-funcs_gen.go
+++ b/pkg/vss/convert/vehicle-convert-funcs_gen.go
@@ -234,17 +234,18 @@ func ToPowertrainCombustionEngineTPS0(originalDoc []byte, val float64) (float64,
 	return val, nil
 }
 
-// ToPowertrainFuelSystemAbsoluteLevel0 converts data from field 'fuelLevel' of type float64 to 'Vehicle.Powertrain.FuelSystem.AbsoluteLevel' of type float64.
-// Vehicle.Powertrain.FuelSystem.AbsoluteLevel: Current available fuel in the fuel tank expressed in liters.
-// Unit: 'l'
-func ToPowertrainFuelSystemAbsoluteLevel0(originalDoc []byte, val float64) (float64, error) {
+// ToPowertrainFuelSystemRelativeLevel0 converts data from field 'fuelLevel' of type float64 to 'Vehicle.Powertrain.FuelSystem.RelativeLevel' of type float64.
+// Vehicle.Powertrain.FuelSystem.RelativeLevel: Level in fuel tank as percent of capacity. 0 = empty. 100 = full.
+// Unit: 'percent' Min: '0' Max: '100'
+func ToPowertrainFuelSystemRelativeLevel0(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 
-// ToPowertrainFuelSystemAbsoluteLevel1 converts data from field 'fuelPercentRemaining' of type float64 to 'Vehicle.Powertrain.FuelSystem.AbsoluteLevel' of type float64.
-// Vehicle.Powertrain.FuelSystem.AbsoluteLevel: Current available fuel in the fuel tank expressed in liters.
-// Unit: 'l'
-func ToPowertrainFuelSystemAbsoluteLevel1(originalDoc []byte, val float64) (float64, error) {
+// ToPowertrainFuelSystemRelativeLevel1 converts data from field 'fuelPercentRemaining' of type float64 to 'Vehicle.Powertrain.FuelSystem.RelativeLevel' of type float64.
+// Vehicle.Powertrain.FuelSystem.RelativeLevel: Level in fuel tank as percent of capacity. 0 = empty. 100 = full.
+// Unit: 'percent' Min: '0' Max: '100'
+func ToPowertrainFuelSystemRelativeLevel1(originalDoc []byte, val float64) (float64, error) {
+	// fuelPercentRemaining comes in as a value between 0 and 1, convert to percentage.
 	return val * 100, nil
 }
 

--- a/pkg/vss/convert/vehicle-convert-funcs_gen.go
+++ b/pkg/vss/convert/vehicle-convert-funcs_gen.go
@@ -307,7 +307,8 @@ func ToPowertrainTractionBatteryGrossCapacity0(originalDoc []byte, val float64) 
 // Vehicle.Powertrain.TractionBattery.StateOfCharge.Current: Physical state of charge of the high voltage battery, relative to net capacity. This is not necessarily the state of charge being displayed to the customer.
 // Unit: 'percent' Min: '0' Max: '100.0'
 func ToPowertrainTractionBatteryStateOfChargeCurrent0(originalDoc []byte, val float64) (float64, error) {
-	return val, nil
+	// soc comes in as a value between 0 and 1, convert to percentage.
+	return val * 100, nil
 }
 
 // ToPowertrainTransmissionTravelledDistance0 converts data from field 'odometer' of type float64 to 'Vehicle.Powertrain.Transmission.TravelledDistance' of type float64.

--- a/pkg/vss/convert/vehicle-convert-funcs_gen.go
+++ b/pkg/vss/convert/vehicle-convert-funcs_gen.go
@@ -277,7 +277,8 @@ func ToPowertrainRange0(originalDoc []byte, val float64) (float64, error) {
 // Vehicle.Powertrain.TractionBattery.Charging.ChargeLimit: Target charge limit (state of charge) for battery.
 // Unit: 'percent' Min: '0' Max: '100'
 func ToPowertrainTractionBatteryChargingChargeLimit0(originalDoc []byte, val float64) (float64, error) {
-	return val, nil
+	// chargeLimit comes in as a value between 0 and 1, convert to percentage.
+	return val * 100, nil
 }
 
 // ToPowertrainTractionBatteryChargingIsCharging0 converts data from field 'charging' of type bool to 'Vehicle.Powertrain.TractionBattery.Charging.IsCharging' of type float64.

--- a/pkg/vss/convert/vehicle-convert-funcs_test.go
+++ b/pkg/vss/convert/vehicle-convert-funcs_test.go
@@ -343,3 +343,57 @@ func TestToDIMOIsLocationRedacted0(t *testing.T) {
 		})
 	}
 }
+
+// Powertrain.Transmission.TravelledDistance
+func TestPowertrainTransmissionTravelledDistance(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		input         float64
+		expected      float64
+		expectedError bool
+	}{
+		{
+			name:          "Positive Value",
+			input:         100.0,
+			expected:      100.0,
+			expectedError: false,
+		},
+		{
+			name:          "Zero Value",
+			input:         0.0,
+			expected:      0.0,
+			expectedError: false,
+		},
+		{
+			name:          "Negative Value",
+			input:         -100.0,
+			expected:      -100.0,
+			expectedError: false,
+		},
+		{
+			name:          "distance in meters",
+			input:         1000.0 * 1000,
+			expected:      1000.0,
+			expectedError: false,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		name := test.name
+		if name == "" {
+			name = fmt.Sprintf("Input: %v", test.input)
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			result, err := convert.ToPowertrainTransmissionTravelledDistance0(nil, test.input)
+			if test.expectedError {
+				require.Error(t, err, "Expected an error but got none")
+			} else {
+				require.NoError(t, err, "Unexpected error")
+				require.Equal(t, test.expected, result, "Unexpected result")
+			}
+		})
+	}
+}

--- a/pkg/vss/convert/vehicle-v1-convert_gen.go
+++ b/pkg/vss/convert/vehicle-v1-convert_gen.go
@@ -910,6 +910,19 @@ func DIMOAftermarketSSIDFromV1Data(jsonData []byte) (ret string, err error) {
 			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.ssid' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
 		}
 	}
+	result = gjson.GetBytes(jsonData, "data.wifi.ssid")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(string)
+		if ok {
+			retVal, err := ToDIMOAftermarketSSID1(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.wifi.ssid': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.wifi.ssid' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
 
 	if errs == nil {
 		return ret, fmt.Errorf("%w 'DIMOAftermarketSSID'", errNotFound)
@@ -933,6 +946,19 @@ func DIMOAftermarketWPAStateFromV1Data(jsonData []byte) (ret string, err error) 
 			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.wpa_state': %w", err))
 		} else {
 			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.wpa_state' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+	result = gjson.GetBytes(jsonData, "data.wifi.wpaState")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(string)
+		if ok {
+			retVal, err := ToDIMOAftermarketWPAState1(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.wifi.wpaState': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.wifi.wpaState' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
 		}
 	}
 
@@ -972,11 +998,24 @@ func DIMOIsLocationRedactedFromV1Data(jsonData []byte) (ret float64, err error) 
 func ExteriorAirTemperatureFromV1Data(jsonData []byte) (ret float64, err error) {
 	var errs error
 	var result gjson.Result
-	result = gjson.GetBytes(jsonData, "data.ambientTemp")
+	result = gjson.GetBytes(jsonData, "data.ambientAirTemp")
 	if result.Exists() && result.Value() != nil {
 		val, ok := result.Value().(float64)
 		if ok {
 			retVal, err := ToExteriorAirTemperature0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.ambientAirTemp': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.ambientAirTemp' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+	result = gjson.GetBytes(jsonData, "data.ambientTemp")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToExteriorAirTemperature1(jsonData, val)
 			if err == nil {
 				return retVal, nil
 			}
@@ -1197,11 +1236,24 @@ func PowertrainCombustionEngineMAFFromV1Data(jsonData []byte) (ret float64, err 
 func PowertrainCombustionEngineSpeedFromV1Data(jsonData []byte) (ret float64, err error) {
 	var errs error
 	var result gjson.Result
-	result = gjson.GetBytes(jsonData, "data.engineSpeed")
+	result = gjson.GetBytes(jsonData, "data.rpm")
 	if result.Exists() && result.Value() != nil {
 		val, ok := result.Value().(float64)
 		if ok {
 			retVal, err := ToPowertrainCombustionEngineSpeed0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.rpm': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.rpm' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+	result = gjson.GetBytes(jsonData, "data.engineSpeed")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToPowertrainCombustionEngineSpeed1(jsonData, val)
 			if err == nil {
 				return retVal, nil
 			}
@@ -1247,11 +1299,24 @@ func PowertrainCombustionEngineTPSFromV1Data(jsonData []byte) (ret float64, err 
 func PowertrainFuelSystemAbsoluteLevelFromV1Data(jsonData []byte) (ret float64, err error) {
 	var errs error
 	var result gjson.Result
-	result = gjson.GetBytes(jsonData, "data.fuelPercentRemaining")
+	result = gjson.GetBytes(jsonData, "data.fuelLevel")
 	if result.Exists() && result.Value() != nil {
 		val, ok := result.Value().(float64)
 		if ok {
 			retVal, err := ToPowertrainFuelSystemAbsoluteLevel0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.fuelLevel': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.fuelLevel' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+	result = gjson.GetBytes(jsonData, "data.fuelPercentRemaining")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToPowertrainFuelSystemAbsoluteLevel1(jsonData, val)
 			if err == nil {
 				return retVal, nil
 			}
@@ -1497,11 +1562,24 @@ func PowertrainTypeFromV1Data(jsonData []byte) (ret string, err error) {
 func SpeedFromV1Data(jsonData []byte) (ret float64, err error) {
 	var errs error
 	var result gjson.Result
-	result = gjson.GetBytes(jsonData, "data.speed")
+	result = gjson.GetBytes(jsonData, "data.vehicleSpeed")
 	if result.Exists() && result.Value() != nil {
 		val, ok := result.Value().(float64)
 		if ok {
 			retVal, err := ToSpeed0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.vehicleSpeed': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.vehicleSpeed' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+	result = gjson.GetBytes(jsonData, "data.speed")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToSpeed1(jsonData, val)
 			if err == nil {
 				return retVal, nil
 			}

--- a/pkg/vss/convert/vehicle-v1-convert_gen.go
+++ b/pkg/vss/convert/vehicle-v1-convert_gen.go
@@ -404,14 +404,14 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, er
 		retSignals = append(retSignals, sig)
 	}
 
-	val, err = PowertrainFuelSystemAbsoluteLevelFromV1Data(jsonData)
+	val, err = PowertrainFuelSystemRelativeLevelFromV1Data(jsonData)
 	if err != nil {
 		if !errors.Is(err, errNotFound) {
-			errs = errors.Join(errs, fmt.Errorf("failed to get 'PowertrainFuelSystemAbsoluteLevel': %w", err))
+			errs = errors.Join(errs, fmt.Errorf("failed to get 'PowertrainFuelSystemRelativeLevel': %w", err))
 		}
 	} else {
 		sig := vss.Signal{
-			Name:      "powertrainFuelSystemAbsoluteLevel",
+			Name:      "powertrainFuelSystemRelativeLevel",
 			TokenID:   baseSignal.TokenID,
 			Timestamp: baseSignal.Timestamp,
 			Source:    baseSignal.Source,
@@ -1295,15 +1295,15 @@ func PowertrainCombustionEngineTPSFromV1Data(jsonData []byte) (ret float64, err 
 	return ret, errs
 }
 
-// PowertrainFuelSystemAbsoluteLevelFromV1Data converts the given JSON data to a float64.
-func PowertrainFuelSystemAbsoluteLevelFromV1Data(jsonData []byte) (ret float64, err error) {
+// PowertrainFuelSystemRelativeLevelFromV1Data converts the given JSON data to a float64.
+func PowertrainFuelSystemRelativeLevelFromV1Data(jsonData []byte) (ret float64, err error) {
 	var errs error
 	var result gjson.Result
 	result = gjson.GetBytes(jsonData, "data.fuelLevel")
 	if result.Exists() && result.Value() != nil {
 		val, ok := result.Value().(float64)
 		if ok {
-			retVal, err := ToPowertrainFuelSystemAbsoluteLevel0(jsonData, val)
+			retVal, err := ToPowertrainFuelSystemRelativeLevel0(jsonData, val)
 			if err == nil {
 				return retVal, nil
 			}
@@ -1316,7 +1316,7 @@ func PowertrainFuelSystemAbsoluteLevelFromV1Data(jsonData []byte) (ret float64, 
 	if result.Exists() && result.Value() != nil {
 		val, ok := result.Value().(float64)
 		if ok {
-			retVal, err := ToPowertrainFuelSystemAbsoluteLevel1(jsonData, val)
+			retVal, err := ToPowertrainFuelSystemRelativeLevel1(jsonData, val)
 			if err == nil {
 				return retVal, nil
 			}
@@ -1327,7 +1327,7 @@ func PowertrainFuelSystemAbsoluteLevelFromV1Data(jsonData []byte) (ret float64, 
 	}
 
 	if errs == nil {
-		return ret, fmt.Errorf("%w 'PowertrainFuelSystemAbsoluteLevel'", errNotFound)
+		return ret, fmt.Errorf("%w 'PowertrainFuelSystemRelativeLevel'", errNotFound)
 	}
 
 	return ret, errs

--- a/pkg/vss/convert/vehicle-v2-convert_gen.go
+++ b/pkg/vss/convert/vehicle-v2-convert_gen.go
@@ -196,7 +196,7 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 			ret = append(ret, sig)
 		}
 	case "fuelLevel":
-		val0, err := PowertrainFuelSystemAbsoluteLevelFromV2Data(originalDoc, valResult)
+		val0, err := PowertrainFuelSystemRelativeLevelFromV2Data(originalDoc, valResult)
 		if err != nil {
 			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'fuelLevel': %w", err))
 		} else {
@@ -204,13 +204,13 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 				TokenID:   baseSignal.TokenID,
 				Timestamp: baseSignal.Timestamp,
 				Source:    baseSignal.Source,
-				Name:      "powertrainFuelSystemAbsoluteLevel",
+				Name:      "powertrainFuelSystemRelativeLevel",
 			}
 			sig.SetValue(val0)
 			ret = append(ret, sig)
 		}
 	case "fuelPercentRemaining":
-		val0, err := PowertrainFuelSystemAbsoluteLevelFromV2Data(originalDoc, valResult)
+		val0, err := PowertrainFuelSystemRelativeLevelFromV2Data(originalDoc, valResult)
 		if err != nil {
 			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'fuelPercentRemaining': %w", err))
 		} else {
@@ -218,7 +218,7 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 				TokenID:   baseSignal.TokenID,
 				Timestamp: baseSignal.Timestamp,
 				Source:    baseSignal.Source,
-				Name:      "powertrainFuelSystemAbsoluteLevel",
+				Name:      "powertrainFuelSystemRelativeLevel",
 			}
 			sig.SetValue(val0)
 			ret = append(ret, sig)
@@ -1119,12 +1119,12 @@ func PowertrainCombustionEngineTPSFromV2Data(originalDoc []byte, result gjson.Re
 	return ret, errs
 }
 
-// PowertrainFuelSystemAbsoluteLevelFromData converts the given JSON data to a float64.
-func PowertrainFuelSystemAbsoluteLevelFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+// PowertrainFuelSystemRelativeLevelFromData converts the given JSON data to a float64.
+func PowertrainFuelSystemRelativeLevelFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
 	var errs error
 	val0, ok := result.Value().(float64)
 	if ok {
-		ret, err = ToPowertrainFuelSystemAbsoluteLevel0(originalDoc, val0)
+		ret, err = ToPowertrainFuelSystemRelativeLevel0(originalDoc, val0)
 		if err == nil {
 			return ret, nil
 		}
@@ -1134,7 +1134,7 @@ func PowertrainFuelSystemAbsoluteLevelFromV2Data(originalDoc []byte, result gjso
 	}
 	val1, ok := result.Value().(float64)
 	if ok {
-		ret, err = ToPowertrainFuelSystemAbsoluteLevel1(originalDoc, val1)
+		ret, err = ToPowertrainFuelSystemRelativeLevel1(originalDoc, val1)
 		if err == nil {
 			return ret, nil
 		}

--- a/pkg/vss/convert/vehicle-v2-convert_gen.go
+++ b/pkg/vss/convert/vehicle-v2-convert_gen.go
@@ -41,6 +41,20 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 			sig.SetValue(val0)
 			ret = append(ret, sig)
 		}
+	case "ambientAirTemp":
+		val0, err := ExteriorAirTemperatureFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'ambientAirTemp': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "exteriorAirTemperature",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
 	case "ambientTemp":
 		val0, err := ExteriorAirTemperatureFromV2Data(originalDoc, valResult)
 		if err != nil {
@@ -177,6 +191,20 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 				Timestamp: baseSignal.Timestamp,
 				Source:    baseSignal.Source,
 				Name:      "powertrainCombustionEngineSpeed",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "fuelLevel":
+		val0, err := PowertrainFuelSystemAbsoluteLevelFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'fuelLevel': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "powertrainFuelSystemAbsoluteLevel",
 			}
 			sig.SetValue(val0)
 			ret = append(ret, sig)
@@ -390,6 +418,20 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 			sig.SetValue(val0)
 			ret = append(ret, sig)
 		}
+	case "rpm":
+		val0, err := PowertrainCombustionEngineSpeedFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'rpm': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "powertrainCombustionEngineSpeed",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
 	case "runTime":
 		val0, err := OBDRunTimeFromV2Data(originalDoc, valResult)
 		if err != nil {
@@ -539,6 +581,48 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 				Timestamp: baseSignal.Timestamp,
 				Source:    baseSignal.Source,
 				Name:      "chassisAxleRow1WheelRightTirePressure",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "vehicleSpeed":
+		val0, err := SpeedFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'vehicleSpeed': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "speed",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "wifi.ssid":
+		val0, err := DIMOAftermarketSSIDFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'wifi.ssid': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "dimoAftermarketSSID",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "wifi.wpaState":
+		val0, err := DIMOAftermarketWPAStateFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'wifi.wpaState': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "dimoAftermarketWPAState",
 			}
 			sig.SetValue(val0)
 			ret = append(ret, sig)
@@ -770,6 +854,16 @@ func DIMOAftermarketSSIDFromV2Data(originalDoc []byte, result gjson.Result) (ret
 	} else {
 		errs = errors.Join(errs, fmt.Errorf("%w, field 'ssid' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
 	}
+	val1, ok := result.Value().(string)
+	if ok {
+		ret, err = ToDIMOAftermarketSSID1(originalDoc, val1)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'wifi.ssid': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'wifi.ssid' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
 
 	return ret, errs
 }
@@ -786,6 +880,16 @@ func DIMOAftermarketWPAStateFromV2Data(originalDoc []byte, result gjson.Result) 
 		errs = errors.Join(errs, fmt.Errorf("failed to convert 'wpa_state': %w", err))
 	} else {
 		errs = errors.Join(errs, fmt.Errorf("%w, field 'wpa_state' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+	val1, ok := result.Value().(string)
+	if ok {
+		ret, err = ToDIMOAftermarketWPAState1(originalDoc, val1)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'wifi.wpaState': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'wifi.wpaState' is not of type 'string' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
 	}
 
 	return ret, errs
@@ -814,6 +918,16 @@ func ExteriorAirTemperatureFromV2Data(originalDoc []byte, result gjson.Result) (
 	val0, ok := result.Value().(float64)
 	if ok {
 		ret, err = ToExteriorAirTemperature0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'ambientAirTemp': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'ambientAirTemp' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+	val1, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToExteriorAirTemperature1(originalDoc, val1)
 		if err == nil {
 			return ret, nil
 		}
@@ -970,6 +1084,16 @@ func PowertrainCombustionEngineSpeedFromV2Data(originalDoc []byte, result gjson.
 		if err == nil {
 			return ret, nil
 		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'rpm': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'rpm' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+	val1, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToPowertrainCombustionEngineSpeed1(originalDoc, val1)
+		if err == nil {
+			return ret, nil
+		}
 		errs = errors.Join(errs, fmt.Errorf("failed to convert 'engineSpeed': %w", err))
 	} else {
 		errs = errors.Join(errs, fmt.Errorf("%w, field 'engineSpeed' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
@@ -1001,6 +1125,16 @@ func PowertrainFuelSystemAbsoluteLevelFromV2Data(originalDoc []byte, result gjso
 	val0, ok := result.Value().(float64)
 	if ok {
 		ret, err = ToPowertrainFuelSystemAbsoluteLevel0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'fuelLevel': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'fuelLevel' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+	val1, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToPowertrainFuelSystemAbsoluteLevel1(originalDoc, val1)
 		if err == nil {
 			return ret, nil
 		}
@@ -1171,6 +1305,16 @@ func SpeedFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err 
 	val0, ok := result.Value().(float64)
 	if ok {
 		ret, err = ToSpeed0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'vehicleSpeed': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'vehicleSpeed' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+	val1, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToSpeed1(originalDoc, val1)
 		if err == nil {
 			return ret, nil
 		}

--- a/pkg/vss/vehicle-structs.go
+++ b/pkg/vss/vehicle-structs.go
@@ -50,8 +50,8 @@ const (
 	FieldPowertrainCombustionEngineSpeed = "powertrainCombustionEngineSpeed"
 	// FieldPowertrainCombustionEngineTPS Current throttle position.
 	FieldPowertrainCombustionEngineTPS = "powertrainCombustionEngineTPS"
-	// FieldPowertrainFuelSystemAbsoluteLevel Current available fuel in the fuel tank expressed in liters.
-	FieldPowertrainFuelSystemAbsoluteLevel = "powertrainFuelSystemAbsoluteLevel"
+	// FieldPowertrainFuelSystemRelativeLevel Level in fuel tank as percent of capacity. 0 = empty. 100 = full.
+	FieldPowertrainFuelSystemRelativeLevel = "powertrainFuelSystemRelativeLevel"
 	// FieldPowertrainFuelSystemSupportedFuelTypes High level information of fuel types supported
 	FieldPowertrainFuelSystemSupportedFuelTypes = "powertrainFuelSystemSupportedFuelTypes"
 	// FieldPowertrainRange Remaining range in meters using all energy sources available in the vehicle.


### PR DESCRIPTION
Update translations to match the following field changes
```json
{
  "ambientAirTemp": "ambientTemp",
  "fuelLevel": "fuelPercentRemaining",
  "longFuelTrim": "longTermFuelTrim1",
  "rpm": "engineSpeed",
  "vehicleSpeed": "speed"
}
```
And value conversions
```c
      root.data = $v2Tov1Mapping.keys().fold({}, key -> key.tally.merge( {if $v2Tov1Mapping.get(key.value) != "" { $v2Tov1Mapping.get(key.value)} else {key.value}:
        if $signalsArray.contains(key.value) && key.value != "fuelLevel" && key.value != "engineLoad" && key.value != "throttlePosition" {
            $signals.filter(item -> item.name == key.value).index(0).value 
        } else if $signalsArray.contains(key.value) {
            $signals.filter(item -> item.name == key.value).index(0).value/100 }
      }))

      # special handling for odometer signal
      let odo = if $signalsArray.contains("odometer") { 
          # if conversion not possible, return 0
          $signals.filter(item -> item.name == "odometer").index(0).value.number(0) 
        } else {
          0
        }
      root.data.odometer = if $odo > 999999 {
          ($odo/1000).round()
        } else if $odo != 0 {
          $odo
        } 
```

These changes reference https://github.com/DIMO-Network/ingest-autopi/blob/314881f9cc1cdde89730c7b68884146ac4c6f099/charts/ingest-autopi/files/resources.yaml#L1036

ref SI-2807
ref SI-2802
ref SI-2817