### PR TITLE
check v1 payloads for vehicleTokenId header.

### DIFF
--- a/pkg/vss/convert/payloadv1_test.go
+++ b/pkg/vss/convert/payloadv1_test.go
@@ -149,3 +149,31 @@ var (
 		{TokenID: 123, Timestamp: ts, Name: "powertrainTransmissionTravelledDistance", ValueNumber: 5024, Source: "dimo/integration/123"},
 	}
 )
+
+func TestWithTokenId(t *testing.T) {
+	t.Parallel()
+	actualSignals, err := convert.SignalsFromPayload(context.Background(), nil, []byte(inputJSONWithTokenId))
+	require.NoErrorf(t, err, "error converting input data: %v", err)
+	require.ElementsMatchf(t, expectedSignalsWithFromTokenId, actualSignals, "converted vehicle does not match expected vehicle")
+}
+
+var (
+	inputJSONWithTokenId = `{
+		"id": "randomIDnumber",
+		"specversion": "1.0",
+		"source": "dimo/integration/123",
+		"subject": "Vehicle123",
+		"time": "2022-01-01T12:34:56Z",
+		"type": "DIMO",
+		"vehicleTokenId": 123,
+		"data": {
+			"odometer": 5024.0,
+			"speed": 25.0
+		}
+	}`
+
+	expectedSignalsWithFromTokenId = []vss.Signal{
+		{TokenID: 123, Timestamp: ts, Name: "speed", ValueNumber: 25.0, Source: "dimo/integration/123"},
+		{TokenID: 123, Timestamp: ts, Name: "powertrainTransmissionTravelledDistance", ValueNumber: 5024, Source: "dimo/integration/123"},
+	}
+)

--- a/pkg/vss/convert/payloadv2.go
+++ b/pkg/vss/convert/payloadv2.go
@@ -21,7 +21,7 @@ func SignalsFromV2Payload(jsonData []byte) ([]vss.Signal, error) {
 	if !signals.IsArray() {
 		return nil, errors.New("signals field is not an array")
 	}
-	tokenID, err := TokenIDFromV2Data(jsonData)
+	tokenID, err := TokenIDFromData(jsonData)
 	if err != nil {
 		return nil, fmt.Errorf("error getting tokenID: %w", err)
 	}
@@ -57,8 +57,8 @@ func SignalsFromV2Payload(jsonData []byte) ([]vss.Signal, error) {
 	return retSignals, errs
 }
 
-// TokenIDFromV2Data gets a tokenID from a V2 payload.
-func TokenIDFromV2Data(jsonData []byte) (uint32, error) {
+// TokenIDFromData gets a tokenID from a V2 payload.
+func TokenIDFromData(jsonData []byte) (uint32, error) {
 	lookupKey := "vehicleTokenId"
 	tokenID := gjson.GetBytes(jsonData, lookupKey)
 	if !tokenID.Exists() {


### PR DESCRIPTION
Checks for vehicleTokenId in vehicle payload for v1 before attempting to decode the id using the tokenGetter.