### PR TITLE
redo of previous PR added 4 new pids

### DIFF
--- a/pkg/schema/spec/definitions.yaml
+++ b/pkg/schema/spec/definitions.yaml
@@ -344,3 +344,31 @@
       isArray: false
   requiredPrivileges:
     - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.AngularVelocity.Yaw
+  conversions: 
+    - originalName: yawRate
+      originalType: float64
+      isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.Powertrain.TractionBattery.Temperature.Average
+  conversions: 
+    - originalName: hvBatteryCoolantTemperature
+      originalType: float64
+      isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.Chassis.Axle.Row1.Wheel.Left.Speed
+  conversions: 
+    - originalName: frontlLeftWheelSpeed
+      originalType: float64
+      isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.Chassis.Axle.Row1.Wheel.Right.Speed
+  conversions: 
+    - originalName: frontRightWheelSpeed
+      originalType: float64
+      isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA

--- a/pkg/vss/convert/vehicle-convert-funcs_gen.go
+++ b/pkg/vss/convert/vehicle-convert-funcs_gen.go
@@ -7,6 +7,20 @@ import "math"
 // any conversion functions already defined in this package will be coppied through.
 // note: DO NOT mutate the orginalDoc parameter which is shared between all conversion functions.
 
+// ToAngularVelocityYaw0 converts data from field 'yawRate' of type float64 to 'Vehicle.AngularVelocity.Yaw' of type float64.
+// Vehicle.AngularVelocity.Yaw: Vehicle rotation rate along Z (vertical).
+// Unit: 'degrees/s'
+func ToAngularVelocityYaw0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToChassisAxleRow1WheelLeftSpeed0 converts data from field 'frontlLeftWheelSpeed' of type float64 to 'Vehicle.Chassis.Axle.Row1.Wheel.Left.Speed' of type float64.
+// Vehicle.Chassis.Axle.Row1.Wheel.Left.Speed: Rotational speed of a vehicle's wheel.
+// Unit: 'km/h'
+func ToChassisAxleRow1WheelLeftSpeed0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
 // ToChassisAxleRow1WheelLeftTirePressure0 converts data from field 'tires.frontLeft' of type float64 to 'Vehicle.Chassis.Axle.Row1.Wheel.Left.Tire.Pressure' of type float64.
 // Vehicle.Chassis.Axle.Row1.Wheel.Left.Tire.Pressure: Tire pressure in kilo-Pascal.
 // Unit: 'kPa'
@@ -18,6 +32,13 @@ func ToChassisAxleRow1WheelLeftTirePressure0(originalDoc []byte, val float64) (f
 // Vehicle.Chassis.Axle.Row1.Wheel.Left.Tire.Pressure: Tire pressure in kilo-Pascal.
 // Unit: 'kPa'
 func ToChassisAxleRow1WheelLeftTirePressure1(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToChassisAxleRow1WheelRightSpeed0 converts data from field 'frontRightWheelSpeed' of type float64 to 'Vehicle.Chassis.Axle.Row1.Wheel.Right.Speed' of type float64.
+// Vehicle.Chassis.Axle.Row1.Wheel.Right.Speed: Rotational speed of a vehicle's wheel.
+// Unit: 'km/h'
+func ToChassisAxleRow1WheelRightSpeed0(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 
@@ -387,6 +408,13 @@ func ToPowertrainTractionBatteryStateOfChargeCurrent0(originalDoc []byte, val fl
 		// soc comes in as a value between 0 and 1, convert to percentage.
 		return val * 100, nil
 	}
+	return val, nil
+}
+
+// ToPowertrainTractionBatteryTemperatureAverage0 converts data from field 'hvBatteryCoolantTemperature' of type float64 to 'Vehicle.Powertrain.TractionBattery.Temperature.Average' of type float64.
+// Vehicle.Powertrain.TractionBattery.Temperature.Average: Current average temperature of the battery cells.
+// Unit: 'celsius'
+func ToPowertrainTractionBatteryTemperatureAverage0(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 

--- a/pkg/vss/convert/vehicle-v1-convert_gen.go
+++ b/pkg/vss/convert/vehicle-v1-convert_gen.go
@@ -20,6 +20,38 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 	var err error
 	var errs []error
 
+	val, err = AngularVelocityYawFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'AngularVelocityYaw': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "angularVelocityYaw",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
+	val, err = ChassisAxleRow1WheelLeftSpeedFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'ChassisAxleRow1WheelLeftSpeed': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "chassisAxleRow1WheelLeftSpeed",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
 	val, err = ChassisAxleRow1WheelLeftTirePressureFromV1Data(jsonData)
 	if err != nil {
 		if !errors.Is(err, errNotFound) {
@@ -28,6 +60,22 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 	} else {
 		sig := vss.Signal{
 			Name:      "chassisAxleRow1WheelLeftTirePressure",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
+	val, err = ChassisAxleRow1WheelRightSpeedFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'ChassisAxleRow1WheelRightSpeed': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "chassisAxleRow1WheelRightSpeed",
 			TokenID:   baseSignal.TokenID,
 			Timestamp: baseSignal.Timestamp,
 			Source:    baseSignal.Source,
@@ -660,6 +708,22 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 		retSignals = append(retSignals, sig)
 	}
 
+	val, err = PowertrainTractionBatteryTemperatureAverageFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'PowertrainTractionBatteryTemperatureAverage': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "powertrainTractionBatteryTemperatureAverage",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
 	val, err = PowertrainTransmissionTravelledDistanceFromV1Data(jsonData)
 	if err != nil {
 		if !errors.Is(err, errNotFound) {
@@ -710,6 +774,56 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 	return retSignals, errs
 }
 
+// AngularVelocityYawFromV1Data converts the given JSON data to a float64.
+func AngularVelocityYawFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.yawRate")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToAngularVelocityYaw0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.yawRate': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.yawRate' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'AngularVelocityYaw'", errNotFound)
+	}
+
+	return ret, errs
+}
+
+// ChassisAxleRow1WheelLeftSpeedFromV1Data converts the given JSON data to a float64.
+func ChassisAxleRow1WheelLeftSpeedFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.frontlLeftWheelSpeed")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToChassisAxleRow1WheelLeftSpeed0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.frontlLeftWheelSpeed': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.frontlLeftWheelSpeed' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'ChassisAxleRow1WheelLeftSpeed'", errNotFound)
+	}
+
+	return ret, errs
+}
+
 // ChassisAxleRow1WheelLeftTirePressureFromV1Data converts the given JSON data to a float64.
 func ChassisAxleRow1WheelLeftTirePressureFromV1Data(jsonData []byte) (ret float64, err error) {
 	var errs error
@@ -743,6 +857,31 @@ func ChassisAxleRow1WheelLeftTirePressureFromV1Data(jsonData []byte) (ret float6
 
 	if errs == nil {
 		return ret, fmt.Errorf("%w 'ChassisAxleRow1WheelLeftTirePressure'", errNotFound)
+	}
+
+	return ret, errs
+}
+
+// ChassisAxleRow1WheelRightSpeedFromV1Data converts the given JSON data to a float64.
+func ChassisAxleRow1WheelRightSpeedFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.frontRightWheelSpeed")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToChassisAxleRow1WheelRightSpeed0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.frontRightWheelSpeed': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.frontRightWheelSpeed' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'ChassisAxleRow1WheelRightSpeed'", errNotFound)
 	}
 
 	return ret, errs
@@ -1835,6 +1974,31 @@ func PowertrainTractionBatteryStateOfChargeCurrentFromV1Data(jsonData []byte) (r
 
 	if errs == nil {
 		return ret, fmt.Errorf("%w 'PowertrainTractionBatteryStateOfChargeCurrent'", errNotFound)
+	}
+
+	return ret, errs
+}
+
+// PowertrainTractionBatteryTemperatureAverageFromV1Data converts the given JSON data to a float64.
+func PowertrainTractionBatteryTemperatureAverageFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.hvBatteryCoolantTemperature")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToPowertrainTractionBatteryTemperatureAverage0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.hvBatteryCoolantTemperature': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.hvBatteryCoolantTemperature' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'PowertrainTractionBatteryTemperatureAverage'", errNotFound)
 	}
 
 	return ret, errs

--- a/pkg/vss/convert/vehicle-v2-convert_gen.go
+++ b/pkg/vss/convert/vehicle-v2-convert_gen.go
@@ -237,6 +237,34 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 			sig.SetValue(val0)
 			ret = append(ret, sig)
 		}
+	case "frontRightWheelSpeed":
+		val0, err := ChassisAxleRow1WheelRightSpeedFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'frontRightWheelSpeed': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "chassisAxleRow1WheelRightSpeed",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "frontlLeftWheelSpeed":
+		val0, err := ChassisAxleRow1WheelLeftSpeedFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'frontlLeftWheelSpeed': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "chassisAxleRow1WheelLeftSpeed",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
 	case "fuelLevel":
 		val0, err := PowertrainFuelSystemRelativeLevelFromV2Data(originalDoc, valResult)
 		if err != nil {
@@ -316,6 +344,20 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 				Timestamp: baseSignal.Timestamp,
 				Source:    baseSignal.Source,
 				Name:      "dimoAftermarketHDOP",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "hvBatteryCoolantTemperature":
+		val0, err := PowertrainTractionBatteryTemperatureAverageFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'hvBatteryCoolantTemperature': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "powertrainTractionBatteryTemperatureAverage",
 			}
 			sig.SetValue(val0)
 			ret = append(ret, sig)
@@ -781,10 +823,58 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 			sig.SetValue(val0)
 			ret = append(ret, sig)
 		}
+	case "yawRate":
+		val0, err := AngularVelocityYawFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'yawRate': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "angularVelocityYaw",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
 	default:
 		// do nothing
 	}
 	return ret, retErrs
+}
+
+// AngularVelocityYawFromData converts the given JSON data to a float64.
+func AngularVelocityYawFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToAngularVelocityYaw0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'yawRate': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'yawRate' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+
+	return ret, errs
+}
+
+// ChassisAxleRow1WheelLeftSpeedFromData converts the given JSON data to a float64.
+func ChassisAxleRow1WheelLeftSpeedFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToChassisAxleRow1WheelLeftSpeed0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'frontlLeftWheelSpeed': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'frontlLeftWheelSpeed' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+
+	return ret, errs
 }
 
 // ChassisAxleRow1WheelLeftTirePressureFromData converts the given JSON data to a float64.
@@ -809,6 +899,23 @@ func ChassisAxleRow1WheelLeftTirePressureFromV2Data(originalDoc []byte, result g
 		errs = errors.Join(errs, fmt.Errorf("failed to convert 'tiresFrontLeft': %w", err))
 	} else {
 		errs = errors.Join(errs, fmt.Errorf("%w, field 'tiresFrontLeft' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+
+	return ret, errs
+}
+
+// ChassisAxleRow1WheelRightSpeedFromData converts the given JSON data to a float64.
+func ChassisAxleRow1WheelRightSpeedFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToChassisAxleRow1WheelRightSpeed0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'frontRightWheelSpeed': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'frontRightWheelSpeed' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
 	}
 
 	return ret, errs
@@ -1562,6 +1669,23 @@ func PowertrainTractionBatteryStateOfChargeCurrentFromV2Data(originalDoc []byte,
 		errs = errors.Join(errs, fmt.Errorf("failed to convert 'soc': %w", err))
 	} else {
 		errs = errors.Join(errs, fmt.Errorf("%w, field 'soc' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
+	}
+
+	return ret, errs
+}
+
+// PowertrainTractionBatteryTemperatureAverageFromData converts the given JSON data to a float64.
+func PowertrainTractionBatteryTemperatureAverageFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToPowertrainTractionBatteryTemperatureAverage0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'hvBatteryCoolantTemperature': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'hvBatteryCoolantTemperature' is not of type 'float64' got '%v' of type '%T'", errInvalidType, result.Value(), result.Value()))
 	}
 
 	return ret, errs

--- a/pkg/vss/vehicle-structs.go
+++ b/pkg/vss/vehicle-structs.go
@@ -2,8 +2,14 @@
 package vss
 
 const (
+	// FieldAngularVelocityYaw Vehicle rotation rate along Z (vertical).
+	FieldAngularVelocityYaw = "angularVelocityYaw"
+	// FieldChassisAxleRow1WheelLeftSpeed Rotational speed of a vehicle's wheel.
+	FieldChassisAxleRow1WheelLeftSpeed = "chassisAxleRow1WheelLeftSpeed"
 	// FieldChassisAxleRow1WheelLeftTirePressure Tire pressure in kilo-Pascal.
 	FieldChassisAxleRow1WheelLeftTirePressure = "chassisAxleRow1WheelLeftTirePressure"
+	// FieldChassisAxleRow1WheelRightSpeed Rotational speed of a vehicle's wheel.
+	FieldChassisAxleRow1WheelRightSpeed = "chassisAxleRow1WheelRightSpeed"
 	// FieldChassisAxleRow1WheelRightTirePressure Tire pressure in kilo-Pascal.
 	FieldChassisAxleRow1WheelRightTirePressure = "chassisAxleRow1WheelRightTirePressure"
 	// FieldChassisAxleRow2WheelLeftTirePressure Tire pressure in kilo-Pascal.
@@ -82,6 +88,8 @@ const (
 	FieldPowertrainTractionBatteryGrossCapacity = "powertrainTractionBatteryGrossCapacity"
 	// FieldPowertrainTractionBatteryStateOfChargeCurrent Physical state of charge of the high voltage battery, relative to net capacity. This is not necessarily the state of charge being displayed to the customer.
 	FieldPowertrainTractionBatteryStateOfChargeCurrent = "powertrainTractionBatteryStateOfChargeCurrent"
+	// FieldPowertrainTractionBatteryTemperatureAverage Current average temperature of the battery cells.
+	FieldPowertrainTractionBatteryTemperatureAverage = "powertrainTractionBatteryTemperatureAverage"
 	// FieldPowertrainTransmissionTravelledDistance Odometer reading, total distance travelled during the lifetime of the transmission.
 	FieldPowertrainTransmissionTravelledDistance = "powertrainTransmissionTravelledDistance"
 	// FieldPowertrainType Defines the powertrain type of the vehicle.


### PR DESCRIPTION
Was getting to many problems with the change of the hvBatteryCoolantTemperature with the make generate. Closed that PR and did this new one. All the information stayed the same. We did have the use Vehicle.Powertrain.TractionBattery.Temperature.Average instead. 

yawRate - (degrees)
VSS Def: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L52
hvBatteryCoolantTemperature-(c)
VSS https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L168
frontlLeftWheelSpeed-(Km/h)
VSS Def: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1052
frontRightWheelSpeed-(Km/h)
VSS Def: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1063
Elastic (This is for all of them): https://kibana.team.dimo.zone/app/discover#/?_g=(refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now))&_a=(columns:!(data.hvBatteryCoolantTemperature,data.yawRate,data.frontlLeftWheelSpeed,data.frontRightWheelSpeed),filters:!(),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'subject:%20%222mWmkUpjcZkoQpu5cBlptbaYu4k%22%20'),sort:!(!(time,desc)))