### PR TITLE
had to redo with same info as other PR from 10/8 

### DIFF
--- a/pkg/nativestatus/vehicle-convert-funcs_gen.go
+++ b/pkg/nativestatus/vehicle-convert-funcs_gen.go
@@ -185,6 +185,13 @@ func ToOBDCommandedEGR0(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 
+// ToOBDCommandedEVAP0 converts data from field 'evap' of type float64 to 'Vehicle.OBD.CommandedEVAP' of type float64.
+// Vehicle.OBD.CommandedEVAP: PID 2E - Commanded evaporative purge (EVAP) valve
+// Unit: 'percent'
+func ToOBDCommandedEVAP0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
 // ToOBDDistanceSinceDTCClear0 converts data from field 'distanceSinceDtcClear' of type float64 to 'Vehicle.OBD.DistanceSinceDTCClear' of type float64.
 // Vehicle.OBD.DistanceSinceDTCClear: PID 31 - Distance traveled since codes cleared
 // Unit: 'km'
@@ -235,6 +242,20 @@ func ToOBDLongTermFuelTrim10(originalDoc []byte, val float64) (float64, error) {
 // Vehicle.OBD.MAP: PID 0B - Intake manifold pressure
 // Unit: 'kPa'
 func ToOBDMAP0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToOBDO2WRSensor1Voltage0 converts data from field 'oxygenSensor1' of type float64 to 'Vehicle.OBD.O2WR.Sensor1.Voltage' of type float64.
+// Vehicle.OBD.O2WR.Sensor1.Voltage: PID 2x (byte CD) - Voltage for wide range/band oxygen sensor
+// Unit: 'V'
+func ToOBDO2WRSensor1Voltage0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToOBDO2WRSensor2Voltage0 converts data from field 'oxygenSensor2' of type float64 to 'Vehicle.OBD.O2WR.Sensor2.Voltage' of type float64.
+// Vehicle.OBD.O2WR.Sensor2.Voltage: PID 2x (byte CD) - Voltage for wide range/band oxygen sensor
+// Unit: 'V'
+func ToOBDO2WRSensor2Voltage0(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 
@@ -435,6 +456,13 @@ func ToPowertrainTractionBatteryTemperatureAverage0(originalDoc []byte, val floa
 // ToPowertrainTransmissionCurrentGear0 converts data from field 'gearSelection' of type float64 to 'Vehicle.Powertrain.Transmission.CurrentGear' of type float64.
 // Vehicle.Powertrain.Transmission.CurrentGear: The current gear. 0=Neutral, 1/2/..=Forward, -1/-2/..=Reverse.
 func ToPowertrainTransmissionCurrentGear0(originalDoc []byte, val float64) (float64, error) {
+	return val, nil
+}
+
+// ToPowertrainTransmissionTemperature0 converts data from field 'atfTemperature' of type float64 to 'Vehicle.Powertrain.Transmission.Temperature' of type float64.
+// Vehicle.Powertrain.Transmission.Temperature: The current gearbox temperature.
+// Unit: 'celsius'
+func ToPowertrainTransmissionTemperature0(originalDoc []byte, val float64) (float64, error) {
 	return val, nil
 }
 

--- a/pkg/nativestatus/vehicle-v1-convert_gen.go
+++ b/pkg/nativestatus/vehicle-v1-convert_gen.go
@@ -325,6 +325,22 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 		retSignals = append(retSignals, sig)
 	}
 
+	val, err = OBDCommandedEVAPFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'OBDCommandedEVAP': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "obdCommandedEVAP",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
 	val, err = OBDDistanceSinceDTCClearFromV1Data(jsonData)
 	if err != nil {
 		if !errors.Is(err, errNotFound) {
@@ -429,6 +445,38 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 	} else {
 		sig := vss.Signal{
 			Name:      "obdMAP",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
+	val, err = OBDO2WRSensor1VoltageFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'OBDO2WRSensor1Voltage': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "obdO2WRSensor1Voltage",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
+	val, err = OBDO2WRSensor2VoltageFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'OBDO2WRSensor2Voltage': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "obdO2WRSensor2Voltage",
 			TokenID:   baseSignal.TokenID,
 			Timestamp: baseSignal.Timestamp,
 			Source:    baseSignal.Source,
@@ -765,6 +813,22 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 	} else {
 		sig := vss.Signal{
 			Name:      "powertrainTransmissionCurrentGear",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
+	val, err = PowertrainTransmissionTemperatureFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'PowertrainTransmissionTemperature': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "powertrainTransmissionTemperature",
 			TokenID:   baseSignal.TokenID,
 			Timestamp: baseSignal.Timestamp,
 			Source:    baseSignal.Source,
@@ -1389,6 +1453,31 @@ func OBDCommandedEGRFromV1Data(jsonData []byte) (ret float64, err error) {
 	return ret, errs
 }
 
+// OBDCommandedEVAPFromV1Data converts the given JSON data to a float64.
+func OBDCommandedEVAPFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.evap")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToOBDCommandedEVAP0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.evap': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.evap' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'OBDCommandedEVAP'", errNotFound)
+	}
+
+	return ret, errs
+}
+
 // OBDDistanceSinceDTCClearFromV1Data converts the given JSON data to a float64.
 func OBDDistanceSinceDTCClearFromV1Data(jsonData []byte) (ret float64, err error) {
 	var errs error
@@ -1559,6 +1648,56 @@ func OBDMAPFromV1Data(jsonData []byte) (ret float64, err error) {
 
 	if errs == nil {
 		return ret, fmt.Errorf("%w 'OBDMAP'", errNotFound)
+	}
+
+	return ret, errs
+}
+
+// OBDO2WRSensor1VoltageFromV1Data converts the given JSON data to a float64.
+func OBDO2WRSensor1VoltageFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.oxygenSensor1")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToOBDO2WRSensor1Voltage0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.oxygenSensor1': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.oxygenSensor1' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'OBDO2WRSensor1Voltage'", errNotFound)
+	}
+
+	return ret, errs
+}
+
+// OBDO2WRSensor2VoltageFromV1Data converts the given JSON data to a float64.
+func OBDO2WRSensor2VoltageFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.oxygenSensor2")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToOBDO2WRSensor2Voltage0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.oxygenSensor2': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.oxygenSensor2' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'OBDO2WRSensor2Voltage'", errNotFound)
 	}
 
 	return ret, errs
@@ -2123,6 +2262,31 @@ func PowertrainTransmissionCurrentGearFromV1Data(jsonData []byte) (ret float64, 
 
 	if errs == nil {
 		return ret, fmt.Errorf("%w 'PowertrainTransmissionCurrentGear'", errNotFound)
+	}
+
+	return ret, errs
+}
+
+// PowertrainTransmissionTemperatureFromV1Data converts the given JSON data to a float64.
+func PowertrainTransmissionTemperatureFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "data.atfTemperature")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(float64)
+		if ok {
+			retVal, err := ToPowertrainTransmissionTemperature0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'data.atfTemperature': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'data.atfTemperature' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'PowertrainTransmissionTemperature'", errNotFound)
 	}
 
 	return ret, errs

--- a/pkg/nativestatus/vehicle-v2-convert_gen.go
+++ b/pkg/nativestatus/vehicle-v2-convert_gen.go
@@ -62,6 +62,20 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 			sig.SetValue(val0)
 			ret = append(ret, sig)
 		}
+	case "atfTemperature":
+		val0, err := PowertrainTransmissionTemperatureFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'atfTemperature': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "powertrainTransmissionTemperature",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
 	case "barometricPressure":
 		val0, err := OBDBarometricPressureFromV2Data(originalDoc, valResult)
 		if err != nil {
@@ -240,6 +254,20 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 				Timestamp: baseSignal.Timestamp,
 				Source:    baseSignal.Source,
 				Name:      "powertrainCombustionEngineTorque",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "evap":
+		val0, err := OBDCommandedEVAPFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'evap': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "obdCommandedEVAP",
 			}
 			sig.SetValue(val0)
 			ret = append(ret, sig)
@@ -560,6 +588,34 @@ func SignalsFromV2Data(originalDoc []byte, baseSignal vss.Signal, signalName str
 				Timestamp: baseSignal.Timestamp,
 				Source:    baseSignal.Source,
 				Name:      "powertrainCombustionEngineEngineOilLevel",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "oxygenSensor1":
+		val0, err := OBDO2WRSensor1VoltageFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'oxygenSensor1': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "obdO2WRSensor1Voltage",
+			}
+			sig.SetValue(val0)
+			ret = append(ret, sig)
+		}
+	case "oxygenSensor2":
+		val0, err := OBDO2WRSensor2VoltageFromV2Data(originalDoc, valResult)
+		if err != nil {
+			retErrs = errors.Join(retErrs, fmt.Errorf("failed to convert 'oxygenSensor2': %w", err))
+		} else {
+			sig := vss.Signal{
+				TokenID:   baseSignal.TokenID,
+				Timestamp: baseSignal.Timestamp,
+				Source:    baseSignal.Source,
+				Name:      "obdO2WRSensor2Voltage",
 			}
 			sig.SetValue(val0)
 			ret = append(ret, sig)
@@ -1271,6 +1327,23 @@ func OBDCommandedEGRFromV2Data(originalDoc []byte, result gjson.Result) (ret flo
 	return ret, errs
 }
 
+// OBDCommandedEVAPFromData converts the given JSON data to a float64.
+func OBDCommandedEVAPFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToOBDCommandedEVAP0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'evap': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'evap' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+	}
+
+	return ret, errs
+}
+
 // OBDDistanceSinceDTCClearFromData converts the given JSON data to a float64.
 func OBDDistanceSinceDTCClearFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
 	var errs error
@@ -1385,6 +1458,40 @@ func OBDMAPFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err
 		errs = errors.Join(errs, fmt.Errorf("failed to convert 'intakePressure': %w", err))
 	} else {
 		errs = errors.Join(errs, fmt.Errorf("%w, field 'intakePressure' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+	}
+
+	return ret, errs
+}
+
+// OBDO2WRSensor1VoltageFromData converts the given JSON data to a float64.
+func OBDO2WRSensor1VoltageFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToOBDO2WRSensor1Voltage0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'oxygenSensor1': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'oxygenSensor1' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+	}
+
+	return ret, errs
+}
+
+// OBDO2WRSensor2VoltageFromData converts the given JSON data to a float64.
+func OBDO2WRSensor2VoltageFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToOBDO2WRSensor2Voltage0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'oxygenSensor2': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'oxygenSensor2' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
 	}
 
 	return ret, errs
@@ -1772,6 +1879,23 @@ func PowertrainTransmissionCurrentGearFromV2Data(originalDoc []byte, result gjso
 		errs = errors.Join(errs, fmt.Errorf("failed to convert 'gearSelection': %w", err))
 	} else {
 		errs = errors.Join(errs, fmt.Errorf("%w, field 'gearSelection' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+	}
+
+	return ret, errs
+}
+
+// PowertrainTransmissionTemperatureFromData converts the given JSON data to a float64.
+func PowertrainTransmissionTemperatureFromV2Data(originalDoc []byte, result gjson.Result) (ret float64, err error) {
+	var errs error
+	val0, ok := result.Value().(float64)
+	if ok {
+		ret, err = ToPowertrainTransmissionTemperature0(originalDoc, val0)
+		if err == nil {
+			return ret, nil
+		}
+		errs = errors.Join(errs, fmt.Errorf("failed to convert 'atfTemperature': %w", err))
+	} else {
+		errs = errors.Join(errs, fmt.Errorf("%w, field 'atfTemperature' is not of type 'float64' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
 	}
 
 	return ret, errs

--- a/pkg/schema/spec/definitions.yaml
+++ b/pkg/schema/spec/definitions.yaml
@@ -393,3 +393,31 @@
       isArray: false
   requiredPrivileges:
     - VEHICLE_NON_LOCATION_DATA 
+- vspecName: Vehicle.Powertrain.Transmission.Temperature
+  conversions: 
+    - originalName: atfTemperature  
+      originalType: float64
+      isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA 
+- vspecName: Vehicle.OBD.O2WR.Sensor1.Voltage
+  conversions: 
+    - originalName: oxygenSensor1 
+      originalType: float64
+      isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA 
+- vspecName: Vehicle.OBD.O2WR.Sensor2.Voltage
+  conversions: 
+    - originalName: oxygenSensor2
+      originalType: float64
+      isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA 
+- vspecName: Vehicle.OBD.CommandedEVAP
+  conversions: 
+   - originalName: evap
+     originalType: float64
+     isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA

--- a/pkg/vss/vehicle-structs.go
+++ b/pkg/vss/vehicle-structs.go
@@ -40,6 +40,8 @@ const (
 	FieldOBDBarometricPressure = "obdBarometricPressure"
 	// FieldOBDCommandedEGR PID 2C - Commanded exhaust gas recirculation (EGR)
 	FieldOBDCommandedEGR = "obdCommandedEGR"
+	// FieldOBDCommandedEVAP PID 2E - Commanded evaporative purge (EVAP) valve
+	FieldOBDCommandedEVAP = "obdCommandedEVAP"
 	// FieldOBDDistanceSinceDTCClear PID 31 - Distance traveled since codes cleared
 	FieldOBDDistanceSinceDTCClear = "obdDistanceSinceDTCClear"
 	// FieldOBDDistanceWithMIL PID 21 - Distance traveled with MIL on
@@ -54,6 +56,10 @@ const (
 	FieldOBDLongTermFuelTrim1 = "obdLongTermFuelTrim1"
 	// FieldOBDMAP PID 0B - Intake manifold pressure
 	FieldOBDMAP = "obdMAP"
+	// FieldOBDO2WRSensor1Voltage PID 2x (byte CD) - Voltage for wide range/band oxygen sensor
+	FieldOBDO2WRSensor1Voltage = "obdO2WRSensor1Voltage"
+	// FieldOBDO2WRSensor2Voltage PID 2x (byte CD) - Voltage for wide range/band oxygen sensor
+	FieldOBDO2WRSensor2Voltage = "obdO2WRSensor2Voltage"
 	// FieldOBDRunTime PID 1F - Engine run time
 	FieldOBDRunTime = "obdRunTime"
 	// FieldOBDShortTermFuelTrim1 PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer
@@ -96,6 +102,8 @@ const (
 	FieldPowertrainTractionBatteryTemperatureAverage = "powertrainTractionBatteryTemperatureAverage"
 	// FieldPowertrainTransmissionCurrentGear The current gear. 0=Neutral, 1/2/..=Forward, -1/-2/..=Reverse.
 	FieldPowertrainTransmissionCurrentGear = "powertrainTransmissionCurrentGear"
+	// FieldPowertrainTransmissionTemperature The current gearbox temperature.
+	FieldPowertrainTransmissionTemperature = "powertrainTransmissionTemperature"
 	// FieldPowertrainTransmissionTravelledDistance Odometer reading, total distance travelled during the lifetime of the transmission.
 	FieldPowertrainTransmissionTravelledDistance = "powertrainTransmissionTravelledDistance"
 	// FieldPowertrainType Defines the powertrain type of the vehicle.


### PR DESCRIPTION
## Supersedes https://github.com/DIMO-Network/model-garage/pull/73

Sorry the PR before was too messed up for my technical skills. Same info bellow. 
Evap: (Percent) (Range 0 to 100 *see below)
VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1206
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(breakdownField:data.evap,columns:!(data.evap,data.model),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.evap%20:%20*%20'),sort:!(!(time,desc)))
Notes:

0% to 5%: When the engine is at idle or just started, the purge valve may be mostly closed, allowing little to no fuel vapor to be sent to the engine.
5% to 15%: During light throttle conditions, the purge valve opens slightly to allow some vapor flow into the engine.
15% to 45%: Under moderate throttle, the purge valve opens more to manage increased vapor flow.
45% to 75%: During higher load conditions (such as acceleration), the purge valve opens significantly to send more vapor to the engine.
75% to 100%: During very high load conditions or certain diagnostic cycles, the purge valve may open fully.
atfTemperature: (C) (70ish to 120ish *see below)
VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L144
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(breakdownField:data.atfTemperature,columns:!(data.model,data.atfTemperature,data.make),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.atfTemperature%20:%20*'),sort:!(!(time,desc)))
Notes:

Below 70°C (158°F): The transmission is relatively cool, often seen when the car has just started or is driving in cold conditions.
70°C to 100°C (158°F to 212°F): This is the normal operating range, where the transmission fluid is working efficiently, and transmission components are protected.
100°C to 120°C (212°F to 248°F): The fluid is starting to get hot, which can lead to accelerated wear of transmission components if sustained over time.
Above 120°C (248°F): The transmission fluid is too hot, and overheating can occur, potentially leading to fluid breakdown and damage to transmission components.
oxygenSensor1 (v) (0-5)
VSS:https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1174
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(data.make,data.model,data.oxygenSensor1),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.oxygenSensor1%20:%20*'),sort:!(!(time,desc)))

oxygenSensor2 (v) (0-5)
VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1178
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(data.make,data.model,data.oxygenSensor2),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.oxygenSensor2%20:%20*'),sort:!(!(time,desc)))

For Oxygen Sensor this is a wideband oxygen pid that is why the range is 0-5. These sensors switch between high and low.
generally speaking the ranges should be between 0.3 to 0.7 because:

Lean mixture (excess oxygen): Voltage will be low, around 0.1 to 0.3 volts.
Rich mixture (excess fuel): Voltage will be higher, around 0.7 to 0.9 volts.
Other Notes:

For AtfTemperature please ignore Silverado 3500 HD, Silverado 2500 HD and Opel Astra...I know these are out of range with wild readings, however they are getting good data back on the rest of the template. Maybe at a later date we make a new template for those MMYs, but right now this is the best spot for them.
For Oxygen Sensors 1 &2 please ignore Chevy Volt readings again same problem as above. It is a plug in hybrid.Evap: (Percent) (Range 0 to 100 *see below)
VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1206
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(breakdownField:data.evap,columns:!(data.evap,data.model),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.evap%20:%20*%20'),sort:!(!(time,desc)))
Notes:

0% to 5%: When the engine is at idle or just started, the purge valve may be mostly closed, allowing little to no fuel vapor to be sent to the engine.
5% to 15%: During light throttle conditions, the purge valve opens slightly to allow some vapor flow into the engine.
15% to 45%: Under moderate throttle, the purge valve opens more to manage increased vapor flow.
45% to 75%: During higher load conditions (such as acceleration), the purge valve opens significantly to send more vapor to the engine.
75% to 100%: During very high load conditions or certain diagnostic cycles, the purge valve may open fully.
atfTemperature: (C) (70ish to 120ish *see below)
VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L144
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(breakdownField:data.atfTemperature,columns:!(data.model,data.atfTemperature,data.make),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.atfTemperature%20:%20*'),sort:!(!(time,desc)))
Notes:

Below 70°C (158°F): The transmission is relatively cool, often seen when the car has just started or is driving in cold conditions.
70°C to 100°C (158°F to 212°F): This is the normal operating range, where the transmission fluid is working efficiently, and transmission components are protected.
100°C to 120°C (212°F to 248°F): The fluid is starting to get hot, which can lead to accelerated wear of transmission components if sustained over time.
Above 120°C (248°F): The transmission fluid is too hot, and overheating can occur, potentially leading to fluid breakdown and damage to transmission components.
oxygenSensor1 (v) (0-5)
VSS:https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1174
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(data.make,data.model,data.oxygenSensor1),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.oxygenSensor1%20:%20*'),sort:!(!(time,desc)))

oxygenSensor2 (v) (0-5)
VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1178
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(data.make,data.model,data.oxygenSensor2),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.oxygenSensor2%20:%20*'),sort:!(!(time,desc)))

For Oxygen Sensor this is a wideband oxygen pid that is why the range is 0-5. These sensors switch between high and low.
generally speaking the ranges should be between 0.3 to 0.7 because:

Lean mixture (excess oxygen): Voltage will be low, around 0.1 to 0.3 volts.
Rich mixture (excess fuel): Voltage will be higher, around 0.7 to 0.9 volts.
Other Notes:

For AtfTemperature please ignore Silverado 3500 HD, Silverado 2500 HD and Opel Astra...I know these are out of range with wild readings, however they are getting good data back on the rest of the template. Maybe at a later date we make a new template for those MMYs, but right now this is the best spot for them.
For Oxygen Sensors 1 &2 please ignore Chevy Volt readings again same problem as above. It is a plug in hybrid.