### PR TITLE
3 new pids added

### DIFF
--- a/pkg/schema/spec/definitions.yaml
+++ b/pkg/schema/spec/definitions.yaml
@@ -421,3 +421,24 @@
      isArray: false
   requiredPrivileges:
     - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.Service.DistanceToService
+  conversions: 
+   - originalName: serviceInterval
+     originalType: float64
+     isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.Powertrain.TractionBattery.CurrentVoltage
+  conversions: 
+   - originalName: hvBatteryVoltage 
+     originalType: float64
+     isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.Powertrain.TractionBattery.Charging.ChargeVoltage.DC
+  conversions: 
+   - originalName: dcConveterRequestedVoltage
+     originalType: float64
+     isArray: false
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA


### PR DESCRIPTION
1) service Interval (KM) 
Notes: 
Electric Vehicles (EVs): Generally have fewer moving parts and require less frequent maintenance. The interval is often around 25,000 to 30,000 kilometers (15,000 to 18,000 miles) for standard service.
Plug-in Hybrid Vehicles (PHEVs): Since they still have internal combustion engines in addition to electric components, service intervals tend to be more frequent, typically every 15,000 to 20,000 kilometers (9,000 to 12,000 miles).
ICE Vehicles: 
- Conventifonal Gasoline Engines: The average service interval is usually around 10,000 to 15,000 kilometers (6,000 to 9,000 miles), 
- Diesel Engines: Diesel The service interval is typically around 10,000 to 20,000 kilometers (6,000 to 12,000 miles).
- High-Performance or Turbocharged Engines: ranging from 8,000 to 12,000 kilometers (5,000 to 7,500 miles) 
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(data.make,data.model,data.serviceInterval),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.serviceInterval%20:%20*%20'),sort:!(!(time,desc)))

VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L1271

2) hvBatteryVoltage (V) (300 - 450) 
Notes: All other MMYs are getting correct voltage besides Audis, because yah they still suck. I turned off the PID on friday for them, but the data is going to still show up. Just ignore them. 

- 300V to 450V for hybrid systems.
- 350V to 450V for fully electric vehicles. 
Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(data.make,data.model,data.hvBatteryVoltage),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.hvBatteryVoltage%20:%20*%20'),sort:!(!(time,desc)))

VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L187

3) dcConverterRequestedVoltage (V) (250-450) 
Notes: The DC-DC converter in electric and hybrid vehicles is responsible for converting the high-voltage (HV) from the vehicle’s main battery (typically between 300V to 450V) to a lower voltage (typically 12V or 48V) to power auxiliary systems, such as the lighting, infotainment, and HVAC systems. We are only getting the high side right now. 

Elastic: https://kibana.team.dimo.zone/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(data.make,data.model,data.dcConverterRequestedVoltage),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:source,index:'325db2b7-a050-4589-b346-2bfd66929719',key:source,negate:!f,params:(query:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk),type:phrase),query:(match_phrase:(source:dimo%2Fintegration%2F27qftVRWQYpVDcO5DltO5Ojbjxk)))),index:'325db2b7-a050-4589-b346-2bfd66929719',interval:auto,query:(language:kuery,query:'data.dcConverterRequestedVoltage%20:%20*%20'),sort:!(!(time,desc)))

VSS: https://github.com/DIMO-Network/model-garage/blob/main/pkg/schema/spec/vss_rel_4.2-DIMO-b2679e5c.csv#L221
