### PR TITLE
tweak lorawan data field type

### DIFF
--- a/pkg/lorawan/lorawan.go
+++ b/pkg/lorawan/lorawan.go
@@ -6,12 +6,12 @@ import (
 )
 
 type LorawanEvent struct {
-	Data           Data    `json:"data"`
-	VehicleTokenID *uint32 `json:"vehicleTokenId"`
-	DeviceTokenID  *uint32 `json:"deviceTokenId"`
-	Signature      string  `json:"signature"`
-	Time           string  `json:"time"`
-	Type           string  `json:"type"`
+	Data           json.RawMessage `json:"data"`
+	VehicleTokenID *uint32         `json:"vehicleTokenId"`
+	DeviceTokenID  *uint32         `json:"deviceTokenId"`
+	Signature      string          `json:"signature"`
+	Time           string          `json:"time"`
+	Type           string          `json:"type"`
 }
 
 // Data represents the data field of a lorawan payload

--- a/pkg/lorawan/status.go
+++ b/pkg/lorawan/status.go
@@ -66,8 +66,11 @@ func ConvertToCloudEvents(msgData []byte, chainID uint64, aftermarketContractAdd
 		return nil, fmt.Errorf("device token id is missing")
 	}
 
-	if event.Data.Header <= 0 {
-		return nil, fmt.Errorf("unknown event frame header: %d", event.Data.Header)
+	var statusData Data
+	err = json.Unmarshal(event.Data, &statusData)
+
+	if statusData.Header <= 0 {
+		return nil, fmt.Errorf("unknown event frame header: %d", statusData.Header)
 	}
 
 	// Construct the producer DID
@@ -87,7 +90,7 @@ func ConvertToCloudEvents(msgData []byte, chainID uint64, aftermarketContractAdd
 		}.String()
 	}
 
-	if event.Data.Header == FingerprintFrame {
+	if statusData.Header == FingerprintFrame {
 		cloudEvent, err := convertToCloudEvent(event, producer, subject, cloudevent.TypeFingerprint)
 		if err != nil {
 			return nil, err
@@ -137,10 +140,7 @@ func createCloudEvent(event LorawanEvent, producer, subject, eventType string) (
 	if err != nil {
 		return cloudevent.CloudEvent[json.RawMessage]{}, fmt.Errorf("failed to parse time: %v", err)
 	}
-	rawData, err := json.Marshal(event.Data)
-	if err != nil {
-		return cloudevent.CloudEvent[json.RawMessage]{}, fmt.Errorf("failed to marshall data: %v", err)
-	}
+
 	return cloudevent.CloudEvent[json.RawMessage]{
 		CloudEventHeader: cloudevent.CloudEventHeader{
 			DataContentType: "application/json",
@@ -155,6 +155,6 @@ func createCloudEvent(event LorawanEvent, producer, subject, eventType string) (
 				"signature": event.Signature,
 			},
 		},
-		Data: rawData,
+		Data: event.Data,
 	}, nil
 }

--- a/pkg/lorawan/status_test.go
+++ b/pkg/lorawan/status_test.go
@@ -20,7 +20,7 @@ func TestConvertToCloudEvents(t *testing.T) {
 	}{
 		{
 			name:             "Status payload",
-			input:            []byte(`{"data":{"header": 2,"device":{"serial":"60d4af69-86e8-b790-02d3-c0a9dc4d6c8a","softwareVersion":"v1.0.0"},"timestamp":1732224181876,"vehicle":{"make":"MINI","model":"Countryman","signals":[{"name":"batteryVoltage","timestamp":1732224181876,"value":12.95}],"year":2018}},"signature":"0x67bdfbfce03ef7c6577a4a64de037db97d882ef158ee6d1b3adc96e0e58599b2508bb74f8780e102e0c50b7b30385ed6160aa8218c9793cb00fc8f8b355a966c1b","time":"2024-11-21T21:23:01.876617869Z","type":"com.dimo.device.status.v2","vehicleTokenId":1, "deviceTokenId": 2222}`),
+			input:            []byte(`{"data":{"header": 2,"device":{"id": "F4CE368CC0DF1D1D","name": "0x3216049F6D65A414E785D1012F70D8944AA1EC44"},"timestamp":1732224181876,"vehicle":{"make":"MINI","model":"Countryman","signals":[{"name":"batteryVoltage","timestamp":1732224181876,"value":12.95}],"year":2018}},"signature":"0x67bdfbfce03ef7c6577a4a64de037db97d882ef158ee6d1b3adc96e0e58599b2508bb74f8780e102e0c50b7b30385ed6160aa8218c9793cb00fc8f8b355a966c1b","time":"2024-11-21T21:23:01.876617869Z","type":"com.dimo.device.status.v2","vehicleTokenId":1, "deviceTokenId": 2222}`),
 			expectError:      false,
 			length:           2,
 			expectedSubject:  "did:nft:2:0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8_1",
@@ -28,7 +28,7 @@ func TestConvertToCloudEvents(t *testing.T) {
 		},
 		{
 			name:             "Status payload with no vehicleTokenId",
-			input:            []byte(`{"data":{"header": 2,"device":{"softwareVersion":"v1.0.0"},"timestamp":1732224181876,"vehicle":{"make":"MINI","model":"Countryman","year":2018}},"time":"2024-11-21T21:23:01.876617869Z","type":"com.dimo.device.status.v2", "deviceTokenId": 2222}`),
+			input:            []byte(`{"data":{"header": 2,"device":{"id": "F4CE368CC0DF1D1D","name": "0x3216049F6D65A414E785D1012F70D8944AA1EC44"},"timestamp":1732224181876,"vehicle":{"make":"MINI","model":"Countryman","year":2018}},"time":"2024-11-21T21:23:01.876617869Z","type":"com.dimo.device.status.v2", "deviceTokenId": 2222}`),
 			expectError:      false,
 			length:           2,
 			expectedSubject:  "",


### PR DESCRIPTION
- reverted type for data field in Cloud Event since it was causing missing vehicle signals and other not-specified fields after unmarshal/marshal operations