### PR TITLE
Obd DTC Count; Added mapping to vss, and ruptela

### DIFF
--- a/pkg/ruptela/conver_signal_funcs_gen.go
+++ b/pkg/ruptela/conver_signal_funcs_gen.go
@@ -171,6 +171,12 @@ func ToOBDRunTime0(originalDoc []byte, val string) (float64, error) {
 	return ignoreZero(Convert107(val))
 }
 
+// ToOBDStatusDTCCount0 converts data from field 'signals.108' of type string to 'Vehicle.OBD.Status.DTCCount' of type float64.
+// Vehicle.OBD.Status.DTCCount: Number of Diagnostic Trouble Codes (DTC)
+func ToOBDStatusDTCCount0(originalDoc []byte, val string) (float64, error) {
+	return Convert108(val)
+}
+
 // ToPowertrainCombustionEngineDieselExhaustFluidCapacity0 converts data from field 'signals.1148' of type string to 'Vehicle.Powertrain.CombustionEngine.DieselExhaustFluid.Capacity' of type float64.
 // Vehicle.Powertrain.CombustionEngine.DieselExhaustFluid.Capacity: Capacity in liters of the Diesel Exhaust Fluid Tank.
 // Unit: 'l'

--- a/pkg/ruptela/convert_signal_status_gen.go
+++ b/pkg/ruptela/convert_signal_status_gen.go
@@ -245,6 +245,22 @@ func SignalsFromV1Data(baseSignal vss.Signal, jsonData []byte) ([]vss.Signal, []
 		retSignals = append(retSignals, sig)
 	}
 
+	val, err = OBDStatusDTCCountFromV1Data(jsonData)
+	if err != nil {
+		if !errors.Is(err, errNotFound) {
+			errs = append(errs, fmt.Errorf("failed to get 'OBDStatusDTCCount': %w", err))
+		}
+	} else {
+		sig := vss.Signal{
+			Name:      "obdStatusDTCCount",
+			TokenID:   baseSignal.TokenID,
+			Timestamp: baseSignal.Timestamp,
+			Source:    baseSignal.Source,
+		}
+		sig.SetValue(val)
+		retSignals = append(retSignals, sig)
+	}
+
 	val, err = PowertrainCombustionEngineDieselExhaustFluidCapacityFromV1Data(jsonData)
 	if err != nil {
 		if !errors.Is(err, errNotFound) {
@@ -825,6 +841,31 @@ func OBDRunTimeFromV1Data(jsonData []byte) (ret float64, err error) {
 
 	if errs == nil {
 		return ret, fmt.Errorf("%w 'OBDRunTime'", errNotFound)
+	}
+
+	return ret, errs
+}
+
+// OBDStatusDTCCountFromV1Data converts the given JSON data to a float64.
+func OBDStatusDTCCountFromV1Data(jsonData []byte) (ret float64, err error) {
+	var errs error
+	var result gjson.Result
+	result = gjson.GetBytes(jsonData, "signals.108")
+	if result.Exists() && result.Value() != nil {
+		val, ok := result.Value().(string)
+		if ok {
+			retVal, err := ToOBDStatusDTCCount0(jsonData, val)
+			if err == nil {
+				return retVal, nil
+			}
+			errs = errors.Join(errs, fmt.Errorf("failed to convert 'signals.108': %w", err))
+		} else {
+			errs = errors.Join(errs, fmt.Errorf("%w, field 'signals.108' is not of type 'string' got '%v' of type '%T'", convert.InvalidTypeError(), result.Value(), result.Value()))
+		}
+	}
+
+	if errs == nil {
+		return ret, fmt.Errorf("%w 'OBDStatusDTCCount'", errNotFound)
 	}
 
 	return ret, errs

--- a/pkg/ruptela/convert_signal_status_test.go
+++ b/pkg/ruptela/convert_signal_status_test.go
@@ -48,6 +48,7 @@ func TestFullFromDataConversion(t *testing.T) {
 		{TokenID: 33, Timestamp: ts, Name: vss.FieldChassisAxleRow2WheelRightTirePressure, ValueNumber: 260.966666, Source: "ruptela/TODO"},
 		{TokenID: 33, Timestamp: ts, Name: vss.FieldPowertrainCombustionEngineEngineOilLevel, ValueString: "HIGH", Source: "ruptela/TODO"},
 		{TokenID: 33, Timestamp: ts, Name: vss.FieldPowertrainCombustionEngineEngineOilRelativeLevel, ValueNumber: 92, Source: "ruptela/TODO"},
+		{TokenID: 33, Timestamp: ts, Name: vss.FieldOBDStatusDTCCount, ValueNumber: 18, Source: "ruptela/TODO"},
 	}
 
 	slices.SortFunc(expectedSignals, sortFunc)
@@ -76,7 +77,7 @@ var fullInputJSON = `
 			"105": "3341413534343438",
 			"106": "3200000000000000",
 			"107": "0",
-			"108": "0",
+			"108": "12",
 			"645": "8",
 			"135": "0",
 			"136": "0",

--- a/pkg/ruptela/multiplier_offset.go
+++ b/pkg/ruptela/multiplier_offset.go
@@ -93,6 +93,30 @@ func Convert107(rawValue string) (float64, error) {
 	return float64(rawInt)*multiplier + offset, nil
 }
 
+// Convert108 converts the given raw value to a float64.
+// Unit: '-' Min: '0'.
+func Convert108(rawValue string) (float64, error) {
+	const byteSize = 2
+	const offset = float64(0)
+	const maxSize = 1<<(byteSize*bitsInByte) - 1
+	const multiplier = float64(1)
+	rawInt, err := strconv.ParseUint(rawValue, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse uint: %w", err)
+	}
+
+	// Check if the value is equal to the maximum value for the given size.
+	if rawInt == maxSize {
+		return 0, errNotFound
+	}
+
+	// Check if the value is less than the minimum value.
+	if rawInt < 0 {
+		return 0, errNotFound
+	}
+	return float64(rawInt)*multiplier + offset, nil
+}
+
 // Convert114 converts the given raw value to a float64.
 // Unit: 'm' Min: '0' Max: '4211081215'.
 func Convert114(rawValue string) (float64, error) {

--- a/pkg/ruptela/schema/ruptela_definitions.yaml
+++ b/pkg/ruptela/schema/ruptela_definitions.yaml
@@ -174,6 +174,11 @@
       originalType: any
       isArray: true
 
+- vspecName: Vehicle.OBD.Status.DTCCount
+  conversions:
+    - originalName: "signals.108"
+      originalType: string
+
 # TODO we only get batteryCapacity in percent SOH
 # - vspecName: Vehicle.Powertrain.TractionBattery.GrossCapacity
 #   conversions:

--- a/pkg/schema/spec/default-definitions.yaml
+++ b/pkg/schema/spec/default-definitions.yaml
@@ -230,3 +230,6 @@
 - vspecName: Vehicle.Powertrain.CombustionEngine.EOP
   requiredPrivileges:
     - VEHICLE_NON_LOCATION_DATA
+- vspecName: Vehicle.OBD.Status.DTCCount
+  requiredPrivileges:
+    - VEHICLE_NON_LOCATION_DATA

--- a/pkg/vss/vehicle-structs.go
+++ b/pkg/vss/vehicle-structs.go
@@ -86,6 +86,8 @@ const (
 	FieldOBDRunTime = "obdRunTime"
 	// FieldOBDShortTermFuelTrim1 PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer
 	FieldOBDShortTermFuelTrim1 = "obdShortTermFuelTrim1"
+	// FieldOBDStatusDTCCount Number of Diagnostic Trouble Codes (DTC)
+	FieldOBDStatusDTCCount = "obdStatusDTCCount"
 	// FieldOBDWarmupsSinceDTCClear PID 30 - Number of warm-ups since codes cleared
 	FieldOBDWarmupsSinceDTCClear = "obdWarmupsSinceDTCClear"
 	// FieldPowertrainCombustionEngineDieselExhaustFluidCapacity Capacity in liters of the Diesel Exhaust Fluid Tank.


### PR DESCRIPTION
The purpose of this new VSS is to be able to see when there are no active DTCs for a vehicle, so that we can clear codes.

VSS notion:
```
Status.DTCCount:
  datatype: uint8
  type: sensor
  Description: Number of Diagnostic Trouble Codes (DTC)
```

Ruptela notion:
Counter for the number of DTCs. No max value, and the min value is 0.

Example case study:

DTC Payload:
```
"data": {
    "dtc_count": "2",
    "dtc_codes": [
      {
        "id": "7e8",
        "code": "P0235"
      },
      {
        "id": "7e8",
        "code": "P00BD"
      }
    ]
```

Status Payload:

```
      "104": "53414C4C41414146",
      "105": "3341413534343438",
      "106": "3200000000000000",
      "107": "8A",
      "108": "2",
      "134": "0",
      "135": "0",
      "136": "0",
```