### PR TITLE
feat: extend ConversionError to support events and use Subject field

### DIFF
--- a/pkg/autopi/convert_signal.go
+++ b/pkg/autopi/convert_signal.go
@@ -21,7 +21,7 @@ func SignalsFromV2Payload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 	signals := gjson.GetBytes(event.Data, "vehicle.signals")
 	if !signals.Exists() {
 		return nil, convert.ConversionError{
-			TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject: event.Subject,
 			Source:  event.Source,
 			Errors:  []error{convert.FieldNotFoundError{Field: "signals", Lookup: "data.vehicle.signals"}},
 		}
@@ -32,7 +32,7 @@ func SignalsFromV2Payload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 			return []vss.Signal{}, nil
 		}
 		return nil, convert.ConversionError{
-			TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject: event.Subject,
 			Source:  event.Source,
 			Errors:  []error{errors.New("signals field is not an array")},
 		}
@@ -44,7 +44,7 @@ func SignalsFromV2Payload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 	}
 
 	conversionErrors := convert.ConversionError{
-		TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+		Subject: event.Subject,
 		Source:  event.Source,
 	}
 	for _, sigData := range signals.Array() {

--- a/pkg/compass/convert_signal.go
+++ b/pkg/compass/convert_signal.go
@@ -27,7 +27,7 @@ func DecodeSignals(ce cloudevent.RawEvent) ([]vss.Signal, error) {
 	sigs, errs := SignalsFromCompass(baseSignal, ce.Data)
 	if len(errs) != 0 {
 		return nil, convert.ConversionError{
-			TokenID:        uint32(tokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject:        ce.Subject,
 			Source:         source,
 			DecodedSignals: sigs,
 			Errors:         errs,

--- a/pkg/convert/errors.go
+++ b/pkg/convert/errors.go
@@ -4,7 +4,6 @@ package convert
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/DIMO-Network/model-garage/pkg/vss"
@@ -35,18 +34,20 @@ func (e FieldNotFoundError) Error() string {
 type ConversionError struct {
 	// DecodedSignals is the list of signals that were successfully decoded.
 	DecodedSignals []vss.Signal `json:"decodedSignals"`
-	Errors         []error      `json:"errors"`
-	TokenID        uint32       `json:"tokenId"`
-	Source         string       `json:"source"`
+	// DecodedEvents is the list of events that were successfully decoded.
+	DecodedEvents []vss.Event `json:"decodedEvents"`
+	Errors        []error     `json:"errors"`
+	Subject       string      `json:"subject"`
+	Source        string      `json:"source"`
 }
 
 // Error returns the error message.
 func (e ConversionError) Error() string {
 	var errBuilder strings.Builder
 	errBuilder.WriteString("conversion error")
-	if e.TokenID != 0 {
-		errBuilder.WriteString(" tokenId '")
-		errBuilder.WriteString(strconv.FormatUint(uint64(e.TokenID), 10))
+	if e.Subject != "" {
+		errBuilder.WriteString(" subject '")
+		errBuilder.WriteString(e.Subject)
 		errBuilder.WriteString("'")
 	}
 

--- a/pkg/hashdog/convert_signal.go
+++ b/pkg/hashdog/convert_signal.go
@@ -20,7 +20,7 @@ func SignalsFromV2Payload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 	signals := gjson.GetBytes(event.Data, "vehicle.signals")
 	if !signals.Exists() {
 		return nil, convert.ConversionError{
-			TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject: event.Subject,
 			Source:  event.Source,
 			Errors:  []error{convert.FieldNotFoundError{Field: "signals", Lookup: "vehicle.signals"}},
 		}
@@ -31,7 +31,7 @@ func SignalsFromV2Payload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 			return []vss.Signal{}, nil
 		}
 		return nil, convert.ConversionError{
-			TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject: event.Subject,
 			Source:  event.Source,
 			Errors:  []error{errors.New("signals field is not an array")},
 		}
@@ -43,7 +43,7 @@ func SignalsFromV2Payload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 	}
 
 	conversionErrors := convert.ConversionError{
-		TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+		Subject: event.Subject,
 		Source:  event.Source,
 	}
 	for _, sigData := range signals.Array() {

--- a/pkg/nativestatus/payloadv1.go
+++ b/pkg/nativestatus/payloadv1.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/DIMO-Network/model-garage/pkg/convert"
@@ -35,7 +36,7 @@ func SignalsFromV1Payload(ctx context.Context, tokenGetter TokenIDGetter, jsonDa
 	source, err := SourceFromData(jsonData)
 	if err != nil {
 		return nil, convert.ConversionError{
-			TokenID: tokenID,
+			Subject: strconv.FormatUint(uint64(tokenID), 10),
 			Errors:  []error{fmt.Errorf("error getting source: %w", err)},
 		}
 	}
@@ -47,7 +48,7 @@ func SignalsFromV1Payload(ctx context.Context, tokenGetter TokenIDGetter, jsonDa
 	sigs, errs := SignalsFromV1Data(baseSignal, jsonData)
 	if errs != nil {
 		return nil, convert.ConversionError{
-			TokenID:        tokenID,
+			Subject:        strconv.FormatUint(uint64(tokenID), 10),
 			Source:         source,
 			DecodedSignals: sigs,
 			Errors:         errs,

--- a/pkg/nativestatus/payloadv2.go
+++ b/pkg/nativestatus/payloadv2.go
@@ -3,6 +3,7 @@ package nativestatus
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/DIMO-Network/model-garage/pkg/convert"
@@ -21,14 +22,14 @@ func SignalsFromV2Payload(jsonData []byte) ([]vss.Signal, error) {
 	source, err := SourceFromData(jsonData)
 	if err != nil {
 		return nil, convert.ConversionError{
-			TokenID: tokenID,
+			Subject: strconv.FormatUint(uint64(tokenID), 10),
 			Errors:  []error{fmt.Errorf("error getting source: %w", err)},
 		}
 	}
 	signals := gjson.GetBytes(jsonData, "data.vehicle.signals")
 	if !signals.Exists() {
 		return nil, convert.ConversionError{
-			TokenID: tokenID,
+			Subject: strconv.FormatUint(uint64(tokenID), 10),
 			Source:  source,
 			Errors:  []error{convert.FieldNotFoundError{Field: "signals", Lookup: "data.vehicle.signals"}},
 		}
@@ -39,7 +40,7 @@ func SignalsFromV2Payload(jsonData []byte) ([]vss.Signal, error) {
 			return []vss.Signal{}, nil
 		}
 		return nil, convert.ConversionError{
-			TokenID: tokenID,
+			Subject: strconv.FormatUint(uint64(tokenID), 10),
 			Source:  source,
 			Errors:  []error{errors.New("signals field is not an array")},
 		}
@@ -51,7 +52,7 @@ func SignalsFromV2Payload(jsonData []byte) ([]vss.Signal, error) {
 	}
 
 	conversionErrors := convert.ConversionError{
-		TokenID: tokenID,
+		Subject: strconv.FormatUint(uint64(tokenID), 10),
 		Source:  source,
 	}
 	for _, sigData := range signals.Array() {

--- a/pkg/ruptela/convert_signal_dtc.go
+++ b/pkg/ruptela/convert_signal_dtc.go
@@ -26,7 +26,7 @@ func SignalsFromDTCPayload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 
 	if errs != nil {
 		return nil, convert.ConversionError{
-			TokenID:        uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject:        event.Subject,
 			Source:         event.Source,
 			DecodedSignals: []vss.Signal{dtcSignal},
 			Errors:         []error{fmt.Errorf("error getting obdDTCList: %w", errs)},

--- a/pkg/ruptela/convert_signal_location.go
+++ b/pkg/ruptela/convert_signal_location.go
@@ -20,7 +20,7 @@ func SignalsFromLocationPayload(event cloudevent.RawEvent) ([]vss.Signal, error)
 	signals := gjson.GetBytes(event.Data, "location")
 	if !signals.Exists() {
 		return nil, convert.ConversionError{
-			TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject: event.Subject,
 			Source:  event.Source,
 			Errors:  []error{convert.FieldNotFoundError{Field: "signals", Lookup: "data.location"}},
 		}
@@ -31,7 +31,7 @@ func SignalsFromLocationPayload(event cloudevent.RawEvent) ([]vss.Signal, error)
 			return []vss.Signal{}, nil
 		}
 		return nil, convert.ConversionError{
-			TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject: event.Subject,
 			Source:  event.Source,
 			Errors:  []error{errors.New("signals field is not an array")},
 		}
@@ -43,7 +43,7 @@ func SignalsFromLocationPayload(event cloudevent.RawEvent) ([]vss.Signal, error)
 	}
 
 	conversionErrors := convert.ConversionError{
-		TokenID: uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+		Subject: event.Subject,
 		Source:  event.Source,
 	}
 	for _, sigData := range signals.Array() {

--- a/pkg/ruptela/convert_signal_status.go
+++ b/pkg/ruptela/convert_signal_status.go
@@ -23,7 +23,7 @@ func SignalsFromV1Payload(event cloudevent.RawEvent) ([]vss.Signal, error) {
 	sigs, errs := SignalsFromV1Data(baseSignal, event.Data)
 	if errs != nil {
 		return nil, convert.ConversionError{
-			TokenID:        uint32(did.TokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject:        event.Subject,
 			Source:         event.Source,
 			DecodedSignals: sigs,
 			Errors:         errs,

--- a/pkg/tesla/api/module.go
+++ b/pkg/tesla/api/module.go
@@ -30,7 +30,7 @@ func SignalConvert(event cloudevent.RawEvent) ([]vss.Signal, error) {
 	sigs, errs := SignalsFromTesla(baseSignal, event.Data)
 	if len(errs) != 0 {
 		return nil, convert.ConversionError{
-			TokenID:        uint32(tokenID.Uint64()), //nolint:gosec // will not exceed uint32 max value
+			Subject:        event.Subject,
 			Source:         source,
 			DecodedSignals: sigs,
 			Errors:         errs,

--- a/pkg/tesla/telemetry/module.go
+++ b/pkg/tesla/telemetry/module.go
@@ -52,7 +52,8 @@ func SignalConvert(event cloudevent.RawEvent) ([]vss.Signal, error) {
 
 	if len(batchedErrs) != 0 {
 		return nil, convert.ConversionError{
-			TokenID:        tokenID,
+			Subject:        event.Subject,
+			Source:         source,
 			DecodedSignals: batchedSigs,
 			Errors:         batchedErrs,
 		}


### PR DESCRIPTION
- Add DecodedEvents field to ConversionError for event conversion partial failures
- Replace TokenID field with Subject field for better generality across data types
- Update event conversion implementations (defaultmodule, ruptela) to use ConversionError
- Update all signal conversion files to use Subject instead of TokenID
- Update native status files to convert tokenID to string for Subject field.