### PR TITLE
Use tupleElement for field access in projection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/99designs/gqlgen v0.17.87
-	github.com/DIMO-Network/clickhouse-infra v0.0.7
+	github.com/DIMO-Network/clickhouse-infra v0.0.8
 	github.com/DIMO-Network/cloudevent v0.2.6
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/ethereum/go-ethereum v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoy
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
 github.com/ClickHouse/clickhouse-go/v2 v2.40.1 h1:PbwsHBgqXRydU7jKULD1C8CHmifczffvQqmFvltM2W4=
 github.com/ClickHouse/clickhouse-go/v2 v2.40.1/go.mod h1:GDzSBLVhladVm8V01aEB36IoBOVLLICfyeuiIp/8Ezc=
-github.com/DIMO-Network/clickhouse-infra v0.0.7 h1:TAsjkFFKu3D5Xg6dwBcRBryjCVSlXsNjVbTwJ4UDlTg=
-github.com/DIMO-Network/clickhouse-infra v0.0.7/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
+github.com/DIMO-Network/clickhouse-infra v0.0.8 h1:54HPXKvNjmn9T0d9ZLYgUm4DnwTavE+Z8admrf39mJI=
+github.com/DIMO-Network/clickhouse-infra v0.0.8/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
 github.com/DIMO-Network/cloudevent v0.2.6 h1:4J2S5aDou+80Kgdh8KK4t8A9C7Leb424Z6dlDuWjA/c=
 github.com/DIMO-Network/cloudevent v0.2.6/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/pkg/migrations/00009_signal_event_latest_projections.sql
+++ b/pkg/migrations/00009_signal_event_latest_projections.sql
@@ -30,8 +30,8 @@ ALTER TABLE signal ADD PROJECTION signal_latest_by_subject_source_name (
         min(timestamp),
         argMax(value_number, timestamp),
         argMax(value_string, timestamp),
-        argMaxIf(value_location, timestamp, (value_location.latitude != 0) OR (value_location.longitude != 0)),
-        maxIf(timestamp, (value_location.latitude != 0) OR (value_location.longitude != 0)),
+        argMaxIf(value_location, timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)),
+        maxIf(timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)),
         argMax(producer, timestamp),
         argMax(cloud_event_id, timestamp),
         count()

--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -16,9 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testCHSettings() config.Settings {
+	return config.Settings{
+		Password: "test-password",
+	}
+}
+
 func TestSignalMigration(t *testing.T) {
 	ctx := context.Background()
-	chcontainer, err := container.CreateClickHouseContainer(ctx, config.Settings{})
+	chcontainer, err := container.CreateClickHouseContainer(ctx, testCHSettings())
 	require.NoError(t, err, "Failed to create clickhouse container")
 
 	defer chcontainer.Terminate(ctx)
@@ -58,9 +64,160 @@ func TestSignalMigration(t *testing.T) {
 	assert.NoError(t, err, "Failed to close clickhouse connection")
 }
 
+func TestSignalInsertAfterMigrations(t *testing.T) {
+	ctx := context.Background()
+	chcontainer, err := container.CreateClickHouseContainer(ctx, testCHSettings())
+	require.NoError(t, err, "Failed to create clickhouse container")
+
+	defer chcontainer.Terminate(ctx)
+
+	db, err := chcontainer.GetClickhouseAsDB()
+	require.NoError(t, err, "Failed to get clickhouse db")
+
+	err = migrations.RunGoose(ctx, []string{"up", "-v"}, db)
+	require.NoError(t, err, "Failed to run migration")
+
+	conn, err := chcontainer.GetClickHouseAsConn()
+	require.NoError(t, err, "Failed to get clickhouse connection")
+
+	signal := vss.Signal{
+		CloudEventHeader: cloudevent.CloudEventHeader{
+			Subject:  "did:erc721:137:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:22892",
+			Source:   "did:ethr:137:0xcd445F4c6bDAD32b68a2939b912150Fe3C88803E",
+			Producer: "did:key:z6MkiTBz1sZ4n4bipYw4v8M4y9Q7gL1Y9s9m4h7G9r2x3w1q",
+		},
+		Data: vss.SignalData{
+			Timestamp:    time.Now().UTC().Truncate(time.Microsecond),
+			Name:         vss.FieldSpeed,
+			ValueNumber:  42,
+			CloudEventID: "signal-insert-regression-test",
+		},
+	}
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO "+vss.TableName)
+	require.NoError(t, err, "Failed to prepare signal batch")
+	defer batch.Close()
+
+	err = batch.Append(vss.SignalToSlice(signal)...)
+	require.NoError(t, err, "Failed to append signal")
+
+	err = batch.Send()
+	require.NoError(t, err, "Failed to send signal")
+
+	rows, err := conn.Query(ctx, fmt.Sprintf("SELECT * FROM %s", vss.TableName))
+	require.NoError(t, err, "Failed to select signal")
+	defer rows.Close()
+
+	signals := []vss.Signal{}
+	for rows.Next() {
+		var signal vss.Signal
+		err = rows.Scan(
+			&signal.Subject,
+			&signal.Data.Timestamp,
+			&signal.Data.Name,
+			&signal.Source,
+			&signal.Producer,
+			&signal.Data.CloudEventID,
+			&signal.Data.ValueNumber,
+			&signal.Data.ValueString,
+			&signal.Data.ValueLocation,
+		)
+		require.NoError(t, err, "Failed to scan signal")
+		signals = append(signals, signal)
+	}
+
+	require.Equal(t, 1, len(signals), "Expected 1 signal")
+	assert.Truef(t, signal.Data.Timestamp.Equal(signals[0].Data.Timestamp), "Signal timestamp mismatch: %v != %v", signal.Data.Timestamp, signals[0].Data.Timestamp)
+	signal.Data.Timestamp = signals[0].Data.Timestamp
+	assert.Equal(t, signal, signals[0], "Signal mismatch")
+
+	err = db.Close()
+	assert.NoError(t, err, "Failed to close DB connection")
+	err = conn.Close()
+	assert.NoError(t, err, "Failed to close clickhouse connection")
+}
+
+func TestSignalLocationInsertAfterMigrations(t *testing.T) {
+	ctx := context.Background()
+	chcontainer, err := container.CreateClickHouseContainer(ctx, testCHSettings())
+	require.NoError(t, err, "Failed to create clickhouse container")
+
+	defer chcontainer.Terminate(ctx)
+
+	db, err := chcontainer.GetClickhouseAsDB()
+	require.NoError(t, err, "Failed to get clickhouse db")
+
+	err = migrations.RunGoose(ctx, []string{"up", "-v"}, db)
+	require.NoError(t, err, "Failed to run migration")
+
+	conn, err := chcontainer.GetClickHouseAsConn()
+	require.NoError(t, err, "Failed to get clickhouse connection")
+
+	signal := vss.Signal{
+		CloudEventHeader: cloudevent.CloudEventHeader{
+			Subject:  "did:erc721:137:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:22892",
+			Source:   "did:ethr:137:0xcd445F4c6bDAD32b68a2939b912150Fe3C88803E",
+			Producer: "did:key:z6MkiTBz1sZ4n4bipYw4v8M4y9Q7gL1Y9s9m4h7G9r2x3w1q",
+		},
+		Data: vss.SignalData{
+			Timestamp:    time.Now().UTC().Truncate(time.Microsecond),
+			Name:         "currentLocationCoordinates",
+			CloudEventID: "signal-location-insert-regression-test",
+			ValueLocation: vss.Location{
+				Latitude:  42.3314,
+				Longitude: -83.0458,
+				HDOP:      0.7,
+				Heading:   135.5,
+			},
+		},
+	}
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO "+vss.TableName)
+	require.NoError(t, err, "Failed to prepare signal batch")
+	defer batch.Close()
+
+	err = batch.Append(vss.SignalToSlice(signal)...)
+	require.NoError(t, err, "Failed to append signal")
+
+	err = batch.Send()
+	require.NoError(t, err, "Failed to send signal")
+
+	rows, err := conn.Query(ctx, fmt.Sprintf("SELECT * FROM %s WHERE name = '%s'", vss.TableName, signal.Data.Name))
+	require.NoError(t, err, "Failed to select signal")
+	defer rows.Close()
+
+	signals := []vss.Signal{}
+	for rows.Next() {
+		var signal vss.Signal
+		err = rows.Scan(
+			&signal.Subject,
+			&signal.Data.Timestamp,
+			&signal.Data.Name,
+			&signal.Source,
+			&signal.Producer,
+			&signal.Data.CloudEventID,
+			&signal.Data.ValueNumber,
+			&signal.Data.ValueString,
+			&signal.Data.ValueLocation,
+		)
+		require.NoError(t, err, "Failed to scan signal")
+		signals = append(signals, signal)
+	}
+
+	require.Equal(t, 1, len(signals), "Expected 1 signal")
+	assert.Truef(t, signal.Data.Timestamp.Equal(signals[0].Data.Timestamp), "Signal timestamp mismatch: %v != %v", signal.Data.Timestamp, signals[0].Data.Timestamp)
+	signal.Data.Timestamp = signals[0].Data.Timestamp
+	assert.Equal(t, signal, signals[0], "Signal mismatch")
+
+	err = db.Close()
+	assert.NoError(t, err, "Failed to close DB connection")
+	err = conn.Close()
+	assert.NoError(t, err, "Failed to close clickhouse connection")
+}
+
 func TestEventMigration(t *testing.T) {
 	ctx := context.Background()
-	chcontainer, err := container.CreateClickHouseContainer(ctx, config.Settings{})
+	chcontainer, err := container.CreateClickHouseContainer(ctx, testCHSettings())
 	require.NoError(t, err, "Failed to create clickhouse container")
 
 	defer chcontainer.Terminate(ctx)


### PR DESCRIPTION
Accessing, e.g., value_location.latitude was erroring when the projection ran. I do not know why this is necessary.

Add tests for inserting both kinds of rows. Upgrade the ClickHouse container version to better match Cloud.