### PR TITLE
Strip leading padding when decoding Ruptela VIN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifneq ($(TAG_COMMIT), $(shell git rev-parse HEAD))
 endif
 
 # Dependency versions
-GOLANGCI_VERSION := latest
+GOLANGCI_VERSION := v2.11.4
 help:
 	@echo "Specify a subcommand:"
 	@grep -hE '^[0-9a-zA-Z_-]+:.*?## .*$$' ${MAKEFILE_LIST} | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-20s\033[m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ ifneq ($(TAG_COMMIT), $(shell git rev-parse HEAD))
 endif
 
 # Dependency versions
+# Pinned: 'latest' resolved to v2.12.2, whose tarball SHA256 doesn't match
+# the checksum baked into the upstream install script.
 GOLANGCI_VERSION := v2.11.4
 help:
 	@echo "Specify a subcommand:"

--- a/pkg/ruptela/convert_fingerprint.go
+++ b/pkg/ruptela/convert_fingerprint.go
@@ -57,7 +57,7 @@ func DecodeFingerprint(event cloudevent.RawEvent) (modelce.Fingerprint, error) {
 		}
 		vinBytes = append(vinBytes, b...)
 	}
-	vinBytes = bytes.TrimRight(vinBytes, "\x00 ")
+	vinBytes = bytes.Trim(vinBytes, "\x00 ")
 	if len(vinBytes) > maxVinLength {
 		vinBytes = vinBytes[:maxVinLength]
 	}

--- a/pkg/ruptela/convert_fingerprint_test.go
+++ b/pkg/ruptela/convert_fingerprint_test.go
@@ -150,11 +150,11 @@ func TestDecodeFingerprint_JapanVIN(t *testing.T) {
 			vinFrame3:   "2000000000000000",
 		},
 		{
-			name:        "Japan VIN B6AW-0050615 with leading space padding",
-			expectedVIN: "B6AW-0050615",
-			vinFrame1:   "2020202020423641",
-			vinFrame2:   "572D303035303631",
-			vinFrame3:   "3500000000000000",
+			name:        "Japan VIN X9YZ-1234567 with leading space padding",
+			expectedVIN: "X9YZ-1234567",
+			vinFrame1:   "2020202020583959",
+			vinFrame2:   "5A2D313233343536",
+			vinFrame3:   "3700000000000000",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/ruptela/convert_fingerprint_test.go
+++ b/pkg/ruptela/convert_fingerprint_test.go
@@ -149,6 +149,13 @@ func TestDecodeFingerprint_JapanVIN(t *testing.T) {
 			vinFrame2:   "3233373334202020",
 			vinFrame3:   "2000000000000000",
 		},
+		{
+			name:        "Japan VIN B6AW-0050615 with leading space padding",
+			expectedVIN: "B6AW-0050615",
+			vinFrame1:   "2020202020423641",
+			vinFrame2:   "572D303035303631",
+			vinFrame3:   "3500000000000000",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `DecodeFingerprint` used `bytes.TrimRight(..., "\x00 ")`, so VIN bytes assembled from PIDs 104/105/106 only had **trailing** nulls and spaces stripped.
- For Ruptela payloads where the first PID is space-padded on the left (e.g. PID 104 = `2020202020...`), the decoded VIN kept its leading spaces. That string then failed both `vin.IsValidVIN()` and `vin.IsValidJapanChassis()` in `dis/internal/processors/fingerprintvalidate`, and the fingerprint message was silently dropped.
- Switching to `bytes.Trim` strips padding on both sides, so a Japanese chassis number like `X9YZ-1234567` now passes validation and produces a fingerprint.

## Test plan

- [x] `go test ./pkg/ruptela/...` — all existing fingerprint decode tests still pass.
- [x] New subtest `Japan VIN X9YZ-1234567 with leading space padding` in `TestDecodeFingerprint_JapanVIN` covers the leading-padding case (synthetic VIN, structurally identical to the real payload that surfaced this bug).

https://claude.ai/code/session_01N6jjMS5NG9iRVCyKfSnHws

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6jjMS5NG9iRVCyKfSnHws)_