### PR TITLE
Use the recommended golangci-lint install URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,7 @@ ifneq ($(TAG_COMMIT), $(shell git rev-parse HEAD))
 endif
 
 # Dependency versions
-# Pinned: 'latest' resolved to v2.12.2, whose tarball SHA256 doesn't match
-# the checksum baked into the upstream install script.
-GOLANGCI_VERSION := v2.11.4
+GOLANGCI_VERSION := latest
 help:
 	@echo "Specify a subcommand:"
 	@grep -hE '^[0-9a-zA-Z_-]+:.*?## .*$$' ${MAKEFILE_LIST} | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-20s\033[m %s\n", $$1, $$2}'
@@ -49,7 +47,7 @@ add-migration: # Add a new migration to the database
 
 tools-golangci-lint: # Install golangci-lint
 	@mkdir -p $(PATHINSTBIN)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- ${GOLANGCI_VERSION}
+	curl -sSfL https://golangci-lint.run/install.sh | BINARY=golangci-lint bash -s -- ${GOLANGCI_VERSION}
 
 tools: tools-golangci-lint # Install all tools
 	go install tool


### PR DESCRIPTION
## Summary

- Switches the `tools-golangci-lint` Makefile target from `https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh` to the canonical `https://golangci-lint.run/install.sh` that golangci-lint [recommends](https://golangci-lint.run/docs/welcome/install/local/#binaries). The `master`-branch script had stale checksums that broke `make tools` for v2.12.2.
- Reverts the v2.11.4 pin added in #261 back to `latest`; the recommended installer keeps its checksums in sync with releases, so the pin isn't needed anymore.

## Test plan

- [ ] CI's `install-tools` job pulls the latest golangci-lint cleanly.

https://claude.ai/code/session_01N6jjMS5NG9iRVCyKfSnHws

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6jjMS5NG9iRVCyKfSnHws)_