### PR TITLE
feat(migrations): signal_latest + summary tables (v1.0.13)

### DIFF
--- a/pkg/migrations/00010_signal_latest.sql
+++ b/pkg/migrations/00010_signal_latest.sql
@@ -1,0 +1,110 @@
+-- +goose Up
+
+-- signal_latest holds the latest state per (subject, kind, name, source) so
+-- latest-value / last-seen queries are point lookups instead of fan-out reads
+-- across every part of the ~97B-row signal table. ReplacingMergeTree keeps the
+-- row with the greatest `timestamp` (the version column) per sorting key at
+-- merge time; readers still use argMax/max at query time so results are exact
+-- before merges complete.
+--
+-- kind = 0: latest raw row for the signal, regardless of value.
+-- kind = 1: latest row whose value_location is not (0, 0) — serves the
+--           "latest valid GPS fix" semantics used by signalsLatest location
+--           fields. Only location-bearing rows are written with kind = 1.
+--           value_number/value_string on kind = 1 rows are not meaningful.
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS signal_latest
+(
+    `subject` String COMMENT 'Subject of the signal, typically a vehicle DID.',
+    `kind` UInt8 COMMENT '0 = latest raw row; 1 = latest non-(0,0)-location row.',
+    `name` LowCardinality(String) COMMENT 'Name of the signal.',
+    `source` LowCardinality(String) COMMENT 'Source of the signal.',
+    `timestamp` DateTime64(6, 'UTC') COMMENT 'Timestamp of the captured row; also the ReplacingMergeTree version.',
+    `value_number` Float64 COMMENT 'Numeric value of the captured row.',
+    `value_string` String COMMENT 'String value of the captured row.',
+    `value_location` Tuple(
+        latitude Float64,
+        longitude Float64,
+        hdop Float64,
+        heading Float64) COMMENT 'Location value of the captured row.'
+)
+ENGINE = ReplacingMergeTree(timestamp)
+ORDER BY (subject, kind, name, source)
+COMMENT 'Latest signal state per (subject, kind, name, source). Fed by signal_latest_raw_mv and signal_latest_loc_mv.';
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE MATERIALIZED VIEW IF NOT EXISTS signal_latest_raw_mv
+TO signal_latest
+AS
+SELECT
+    subject,
+    0 AS kind,
+    name,
+    source,
+    timestamp,
+    value_number,
+    value_string,
+    value_location
+FROM signal;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE MATERIALIZED VIEW IF NOT EXISTS signal_latest_loc_mv
+TO signal_latest
+AS
+SELECT
+    subject,
+    1 AS kind,
+    name,
+    source,
+    timestamp,
+    value_number,
+    value_string,
+    value_location
+FROM signal
+WHERE (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0);
+-- +goose StatementEnd
+
+-- Backfill is NOT part of the migration: it aggregates the full signal table
+-- and must be run by an operator once, after this migration is applied and
+-- before telemetry-api switches to signal_latest. Overlap between the MVs and
+-- the backfill is collapsed by the ReplacingMergeTree version. Operator SQL is
+-- documented in the implementation plan (Phase 2) and duplicated here:
+--
+--   INSERT INTO signal_latest
+--   SELECT subject, 0 AS kind, name, source,
+--          max(timestamp) AS timestamp,
+--          argMax(value_number, timestamp) AS value_number,
+--          argMax(value_string, timestamp) AS value_string,
+--          argMax(value_location, timestamp) AS value_location
+--   FROM signal
+--   GROUP BY subject, name, source
+--   SETTINGS max_execution_time = 0, max_memory_usage = 0,
+--            max_bytes_before_external_group_by = 32000000000;
+--
+--   INSERT INTO signal_latest
+--   SELECT subject, 1 AS kind, name, source,
+--          maxIf(timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)) AS timestamp,
+--          0 AS value_number, '' AS value_string,
+--          argMaxIf(value_location, timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)) AS value_location
+--   FROM signal
+--   GROUP BY subject, name, source
+--   HAVING timestamp > toDateTime64(0, 6)
+--   SETTINGS max_execution_time = 0, max_memory_usage = 0,
+--            max_bytes_before_external_group_by = 32000000000;
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS signal_latest_loc_mv;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS signal_latest_raw_mv;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS signal_latest;
+-- +goose StatementEnd

--- a/pkg/migrations/00010_signal_latest.sql
+++ b/pkg/migrations/00010_signal_latest.sql
@@ -73,25 +73,31 @@ WHERE (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_loc
 -- the backfill is collapsed by the ReplacingMergeTree version. Operator SQL is
 -- documented in the implementation plan (Phase 2) and duplicated here:
 --
---   INSERT INTO signal_latest
---   SELECT subject, 0 AS kind, name, source,
---          max(timestamp) AS timestamp,
---          argMax(value_number, timestamp) AS value_number,
---          argMax(value_string, timestamp) AS value_string,
---          argMax(value_location, timestamp) AS value_location
+-- NOTE: do not alias the aggregates to source-column names (e.g.
+-- max(timestamp) AS timestamp): the alias shadows the column inside the other
+-- aggregates and ClickHouse rejects the query with "aggregate function found
+-- inside another aggregate function" (error 184). The explicit INSERT column
+-- list maps the SELECT positionally instead.
+--
+--   INSERT INTO signal_latest (subject, kind, name, source, timestamp, value_number, value_string, value_location)
+--   SELECT subject, 0, name, source,
+--          max(timestamp) AS ts,
+--          argMax(value_number, timestamp),
+--          argMax(value_string, timestamp),
+--          argMax(value_location, timestamp)
 --   FROM signal
 --   GROUP BY subject, name, source
 --   SETTINGS max_execution_time = 0, max_memory_usage = 0,
 --            max_bytes_before_external_group_by = 32000000000;
 --
---   INSERT INTO signal_latest
---   SELECT subject, 1 AS kind, name, source,
---          maxIf(timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)) AS timestamp,
---          0 AS value_number, '' AS value_string,
---          argMaxIf(value_location, timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)) AS value_location
+--   INSERT INTO signal_latest (subject, kind, name, source, timestamp, value_number, value_string, value_location)
+--   SELECT subject, 1, name, source,
+--          maxIf(timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)) AS ts,
+--          0, '',
+--          argMaxIf(value_location, timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0))
 --   FROM signal
 --   GROUP BY subject, name, source
---   HAVING timestamp > toDateTime64(0, 6)
+--   HAVING ts > toDateTime64(0, 6)
 --   SETTINGS max_execution_time = 0, max_memory_usage = 0,
 --            max_bytes_before_external_group_by = 32000000000;
 

--- a/pkg/migrations/00011_summary_tables.sql
+++ b/pkg/migrations/00011_summary_tables.sql
@@ -72,13 +72,13 @@ GROUP BY subject, name, source;
 
 -- Operator backfill (run once, after applying, before telemetry-api switches):
 --
---   INSERT INTO signal_summary
+--   INSERT INTO signal_summary (subject, name, source, count, first_seen, last_seen)
 --   SELECT subject, name, source, toUInt64(count()), min(timestamp), max(timestamp)
 --   FROM signal GROUP BY subject, name, source
 --   SETTINGS max_execution_time = 0, max_memory_usage = 0,
 --            max_bytes_before_external_group_by = 32000000000;
 --
---   INSERT INTO event_summary
+--   INSERT INTO event_summary (subject, name, source, count, first_seen, last_seen)
 --   SELECT subject, name, source, toUInt64(count()), min(timestamp), max(timestamp)
 --   FROM event GROUP BY subject, name, source
 --   SETTINGS max_execution_time = 0, max_memory_usage = 0,

--- a/pkg/migrations/00011_summary_tables.sql
+++ b/pkg/migrations/00011_summary_tables.sql
@@ -1,0 +1,108 @@
+-- +goose Up
+
+-- Per-name summaries (count, first seen, last seen) for the dataSummary API.
+-- AggregatingMergeTree with SimpleAggregateFunction columns: the MV emits one
+-- partially-aggregated row per insert block, merges combine them (sum/min/max),
+-- and readers re-aggregate at query time, so results are exact regardless of
+-- merge state.
+--
+-- Count semantics: counts are over raw inserted rows. The signal/event tables
+-- are ReplacingMergeTree, so rows deduplicated there later are still counted
+-- here. The previous count(*) reads (no FINAL) were equally approximate.
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS signal_summary
+(
+    `subject` String COMMENT 'Subject of the signal, typically a vehicle DID.',
+    `name` LowCardinality(String) COMMENT 'Name of the signal.',
+    `source` LowCardinality(String) COMMENT 'Source of the signal.',
+    `count` SimpleAggregateFunction(sum, UInt64) COMMENT 'Number of rows inserted for this signal.',
+    `first_seen` SimpleAggregateFunction(min, DateTime64(6, 'UTC')) COMMENT 'Earliest timestamp for this signal.',
+    `last_seen` SimpleAggregateFunction(max, DateTime64(6, 'UTC')) COMMENT 'Latest timestamp for this signal.'
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (subject, name, source)
+COMMENT 'Per-signal summary per (subject, name, source). Fed by signal_summary_mv.';
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE MATERIALIZED VIEW IF NOT EXISTS signal_summary_mv
+TO signal_summary
+AS
+SELECT
+    subject,
+    name,
+    source,
+    toUInt64(count()) AS count,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+FROM signal
+GROUP BY subject, name, source;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS event_summary
+(
+    `subject` String COMMENT 'Subject of the event, typically a vehicle DID.',
+    `name` LowCardinality(String) COMMENT 'Name of the event.',
+    `source` LowCardinality(String) COMMENT 'Source of the event.',
+    `count` SimpleAggregateFunction(sum, UInt64) COMMENT 'Number of rows inserted for this event name.',
+    `first_seen` SimpleAggregateFunction(min, DateTime64(6, 'UTC')) COMMENT 'Earliest timestamp for this event name.',
+    `last_seen` SimpleAggregateFunction(max, DateTime64(6, 'UTC')) COMMENT 'Latest timestamp for this event name.'
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (subject, name, source)
+COMMENT 'Per-event summary per (subject, name, source). Fed by event_summary_mv.';
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE MATERIALIZED VIEW IF NOT EXISTS event_summary_mv
+TO event_summary
+AS
+SELECT
+    subject,
+    name,
+    source,
+    toUInt64(count()) AS count,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+FROM event
+GROUP BY subject, name, source;
+-- +goose StatementEnd
+
+-- Operator backfill (run once, after applying, before telemetry-api switches):
+--
+--   INSERT INTO signal_summary
+--   SELECT subject, name, source, toUInt64(count()), min(timestamp), max(timestamp)
+--   FROM signal GROUP BY subject, name, source
+--   SETTINGS max_execution_time = 0, max_memory_usage = 0,
+--            max_bytes_before_external_group_by = 32000000000;
+--
+--   INSERT INTO event_summary
+--   SELECT subject, name, source, toUInt64(count()), min(timestamp), max(timestamp)
+--   FROM event GROUP BY subject, name, source
+--   SETTINGS max_execution_time = 0, max_memory_usage = 0,
+--            max_bytes_before_external_group_by = 32000000000;
+--
+-- IMPORTANT: backfill must run BEFORE meaningful MV data accumulates or counts
+-- double. Practically: run both backfills immediately after the migration
+-- applies, then correct the overlap window if needed (counts are approximate
+-- by design; first/last_seen are idempotent under overlap).
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS event_summary_mv;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP VIEW IF EXISTS signal_summary_mv;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS event_summary;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS signal_summary;
+-- +goose StatementEnd


### PR DESCRIPTION
Adds `signal_latest` (ReplacingMergeTree(timestamp) keyed `(subject, kind, name, source)` + 2 MVs) and `signal_summary`/`event_summary` (AggregatingMergeTree + MVs). These replace the per-part latest projections that pessimize signalsLatest: projections are stored per part, so latest-state reads inherit the ~140-part fan-out — measured p50 ~3s via projection vs ~110ms raw primary-key reads (prod, 2026-06-11).

- kind=0 rows mirror every signal row (latest raw value); kind=1 rows mirror only non-(0,0)-location rows (latest valid GPS fix, preserves argMaxIf semantics).
- Readers aggregate at query time (argMax/max/sum/min) — results exact regardless of merge state; FINAL never used.
- Backfill is operator-run, SQL documented in the migration comments.

**Rollout:** this PR = v1.0.13 (00010+00011) → operator backfill → telemetry-api switches reads → separate PR with 00012 (drop projections) = v1.0.14 after 24h soak. 00012 is deliberately NOT in this PR so `goose up` can never drop projections before telemetry-api has switched.