### PR TITLE
feat(migrations): drop per-part latest projections (v1.0.14 — HOLD until telemetry-api switch + 24h soak)

### DIFF
--- a/pkg/migrations/00012_drop_latest_projections.sql
+++ b/pkg/migrations/00012_drop_latest_projections.sql
@@ -1,0 +1,73 @@
+-- +goose Up
+
+-- The per-part latest projections inherited the signal table's part fan-out
+-- (projections are stored per part) with fatter aggregate-state granules, and
+-- measured slower than raw primary-key reads in prod (signalsLatest p50 ~3s
+-- via projection vs ~110ms raw, 2026-06-11). signal_latest (00010) and the
+-- summary tables (00011) replace them. Apply only after telemetry-api reads
+-- the new tables (this migration ships in a later model-garage release to
+-- enforce that ordering).
+
+-- +goose StatementBegin
+ALTER TABLE signal DROP PROJECTION IF EXISTS signal_latest_by_subject_source_name;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE event DROP PROJECTION IF EXISTS event_latest_by_subject_source_name;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE signal RESET SETTING deduplicate_merge_projection_mode;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE event RESET SETTING deduplicate_merge_projection_mode;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- Recreate the projections as defined in migration 00009. Re-materializing is
+-- an operator decision (heavy mutation); without it the projections only
+-- cover parts written after this rollback.
+
+-- +goose StatementBegin
+ALTER TABLE signal MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE event MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE signal ADD PROJECTION IF NOT EXISTS signal_latest_by_subject_source_name (
+    SELECT
+        subject,
+        source,
+        name,
+        max(timestamp),
+        min(timestamp),
+        argMax(value_number, timestamp),
+        argMax(value_string, timestamp),
+        argMaxIf(value_location, timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)),
+        maxIf(timestamp, (tupleElement(value_location, 'latitude') != 0) OR (tupleElement(value_location, 'longitude') != 0)),
+        argMax(producer, timestamp),
+        argMax(cloud_event_id, timestamp),
+        count()
+    GROUP BY subject, source, name
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE event ADD PROJECTION IF NOT EXISTS event_latest_by_subject_source_name (
+    SELECT
+        subject,
+        source,
+        name,
+        max(timestamp),
+        min(timestamp),
+        argMax(producer, timestamp),
+        argMax(cloud_event_id, timestamp),
+        count()
+    GROUP BY subject, source, name
+);
+-- +goose StatementEnd


### PR DESCRIPTION
Drops `signal_latest_by_subject_source_name` and `event_latest_by_subject_source_name` and resets `deduplicate_merge_projection_mode`. Superseded by signal_latest/summary tables (#263).

**HARD GATE — do not merge/tag until:**
1. telemetry-api release reading signal_latest/summary tables is deployed and verified stable 24h.
2. prod query_log shows zero projection-matched app queries in 24h:
```sql
SELECT count() FROM clusterAllReplicas(default, system.query_log)
WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL 24 HOUR
  AND notEmpty(projections);
```
Dropping while anything still emits projection-matched shapes sends those queries to full-history scans (~10s, the original incident — worse than the ~3s projection path).

Stacked on #263; retarget to main after it merges. Tag v1.0.14 from this merge.