### PR TITLE
feat(kaufmann): route Kaufmann source by ds (ruptela + Kamaleon/default)

### DIFF
--- a/docs/adr/0001-kaufmann-connection-ds-routing.md
+++ b/docs/adr/0001-kaufmann-connection-ds-routing.md
@@ -1,0 +1,111 @@
+# ADR 0001 — Route the Kaufmann connection source by CloudEvent `ds`
+
+- **Status:** Accepted
+- **Date:** 2026-07-23
+- **Deciders:** DIMO platform / Kaufmann oracle work
+- **Related:** `pkg/kaufmann`, `pkg/modules/register.go`; kaufmann-oracle#164 (oracle
+  side), kaufmann-oracle#165; the DIS wiring change (below)
+
+## Context
+
+The **Kaufmann connection license**
+(`0x8D8cDB2B26423c8fDbb27321aF20b4659Ce919fD`) started out carrying a single
+device family — Ruptela **Smart5** trackers — and was therefore registered
+straight to the **ruptela** module in `pkg/modules/register.go`.
+
+The Kaufmann oracle now also ingests **Queclink GV58 / GV300W** devices that
+relay **Kamaleon** telemetry through a flespi proxy. Two facts make these
+incompatible with the ruptela decoder:
+
+1. **Different payload shape.** Ruptela telemetry is a `data.signals` map of
+   numeric Ruptela IO ids (e.g. `"104"`, `"105"`, `"106"` for VIN) with
+   Ruptela-specific encodings and scale factors. Kamaleon frames are a
+   completely different ASCII record format.
+2. **The oracle already decodes Kamaleon.** Rather than teach a server-side
+   decoder the Kamaleon record schema, the oracle pre-decodes each frame into
+   **VSS-named signals** and emits them in the DIS **default module** payload
+   shape (`data.signals: [{name, value, timestamp}]`).
+
+So one connection now carries **two payload families**, and they must be decoded
+by two different modules. They are distinguished by the CloudEvent **`ds`**
+(data version): the oracle tags Ruptela events `r/v0/*` and Kamaleon events
+`kam/v0/*`.
+
+The CloudEvent **header** is identical for both families: producer = the
+**synthetic device** NFT DID, subject = the **vehicle** NFT DID, both built from
+the `deviceTokenId` / `vehicleTokenId` in the envelope. Only the *payload
+decoding* differs.
+
+## Decision
+
+Introduce **`pkg/kaufmann.Module`**, registered for `KaufmannSource` in all four
+registries in place of the ruptela module. It implements the CloudEvent, Signal,
+Fingerprint, and Event module interfaces and **routes on the `ds` prefix**:
+
+| `ds` prefix | Handling |
+|---|---|
+| `r/…`   | Delegated to the **ruptela** module (unchanged historical behavior). |
+| `kam/…` | Signal/event/fingerprint decoding delegated to the **default** module (the payload is already VSS); CloudEvent header built locally. |
+
+Header construction is shared: for the `kam/` family the module builds the
+status CloudEvent header directly (producer = synthetic DID, subject = vehicle
+DID) using its configured chain id and contract addresses, mirroring exactly what
+the ruptela module does for `r/v0/s`. The `r/` family delegates header
+construction to the ruptela module.
+
+`DIS` configures the CloudEvent registration for `KaufmannSource` with a
+contract-configured `kaufmann.Module` (with `AftermarketContractAddr` set to the
+**synthetic device** contract, since Kaufmann devices are synthetic devices),
+replacing the previous `ruptela.Module` override. The signal/event/fingerprint
+registries use the zero-value module from `register.go` (those paths don't build
+DIDs, so they need no contract config).
+
+## Consequences
+
+**Positive**
+
+- One connection license and one mTLS identity serve both hardware families; no
+  new on-chain connection, cert, or synthetic-device minting token id is needed.
+- All Kamaleon record knowledge stays in the **oracle**; model-garage only
+  routes. DIS is unchanged apart from a dependency bump and the one-line
+  registration swap.
+- Existing Ruptela behavior is untouched and covered by a delegation regression
+  test, so the change is low-risk for the existing fleet.
+- Adding a future family on this connection is a new `ds` prefix and one more
+  branch — no new source/license.
+
+**Negative / trade-offs**
+
+- The Kaufmann source now has slightly more logic than a plain module alias, and
+  a reader must know that `ds` is the routing key.
+- Header construction for `kam/` is a small duplication of the ruptela header
+  logic (kept intentionally, to avoid coupling the two decoders).
+- The oracle and this module share an implicit **wire contract** (the `kam/`
+  envelope shape). It is documented in the oracle repo
+  (`docs/flespi-to-dis-plan.md`) and pinned by golden tests on both sides.
+
+## Alternatives considered
+
+- **A. Masquerade Kamaleon as Ruptela** — map Kamaleon fields onto Ruptela
+  numeric IO ids/encodings in the oracle so the existing ruptela decoder handles
+  them. *Rejected:* semantically wrong (per-IO encodings and scale factors differ,
+  e.g. Ruptela IO 114 odometer = value×5), lossy (only overlapping signals), and
+  it pollutes the `r/` schema.
+- **B. A second connection license / source** — give Kamaleon its own source
+  address, which falls through to the default module for free. *Rejected:*
+  operationally heavy — a new on-chain license, a second mTLS cert, a second
+  connection token id for synthetic-device minting, and a fleet split across two
+  connections — for no functional gain over routing by `ds`.
+- **C. Route by `ds` in a Kaufmann module (chosen)** — confines the change to
+  model-garage routing (~a module) plus a DIS dependency bump, keeps Kamaleon
+  decoding in the oracle, and leaves Ruptela untouched.
+
+## References
+
+- `pkg/kaufmann/module.go`, `pkg/kaufmann/module_test.go`
+- `pkg/modules/register.go` (`KaufmannSource` registration)
+- Oracle side: kaufmann-oracle `internal/kamaleon/cloudevent.go` (emits the
+  `kam/v0/s` envelope) and `docs/flespi-to-dis-plan.md` (Option C plan + wire
+  contract)
+- DIS side: `internal/processors/cloudeventconvert/cloudeventconvert.go` overrides
+  `KaufmannSource` with a contract-configured `kaufmann.Module`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+This folder holds Architecture Decision Records (ADRs): short documents capturing
+a significant decision, its context, and its consequences — the *why* behind a
+change, complementing the per-module reference docs (`pkg/<module>/<MODULE>.md`).
+
+Format: [Michael Nygard's ADR template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+Files are numbered sequentially, `NNNN-short-title.md`.
+
+## Index
+
+- [0001 — Route the Kaufmann connection source by CloudEvent `ds`](0001-kaufmann-connection-ds-routing.md)

--- a/pkg/kaufmann/module.go
+++ b/pkg/kaufmann/module.go
@@ -1,0 +1,155 @@
+// Package kaufmann handles the Kaufmann connection license, which carries two
+// telemetry families on a single connection, distinguished by the CloudEvent
+// `ds` (data version):
+//
+//   - "r/..."   Ruptela Smart5 telemetry (numeric IO-id signals). Decoded by the
+//     ruptela module — the historical behavior for this source.
+//   - "kam/..." Queclink/Kamaleon telemetry that the Kaufmann oracle has already
+//     decoded into VSS-named signals. Decoded by the default module.
+//
+// CloudEvent headers are identical for both families: the producer is the
+// synthetic device NFT DID and the subject is the vehicle NFT DID, both built
+// from the token ids in the envelope. Only signal/event/fingerprint decoding
+// forks on the ds.
+package kaufmann
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/DIMO-Network/cloudevent"
+	modelce "github.com/DIMO-Network/model-garage/pkg/cloudevent"
+	"github.com/DIMO-Network/model-garage/pkg/defaultmodule"
+	"github.com/DIMO-Network/model-garage/pkg/ruptela"
+	"github.com/DIMO-Network/model-garage/pkg/vss"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/segmentio/ksuid"
+)
+
+// kamDSPrefix marks the Kamaleon payload family. Events whose ds has this prefix
+// carry oracle-decoded VSS signals and are handled by the default module; every
+// other ds (the "r/" family) keeps ruptela handling.
+const kamDSPrefix = "kam/"
+
+// defaultMod decodes the Kamaleon (already-VSS) payloads. It is stateless aside
+// from a lazily-built, concurrency-safe signal map, so a single shared instance
+// is fine.
+var defaultMod = &defaultmodule.Module{}
+
+// Module routes Kaufmann events to the ruptela or default module based on ds. Its
+// contract configuration matches how DIS configures the ruptela module for the
+// Kaufmann source: AftermarketContractAddr is the synthetic device contract.
+type Module struct {
+	ChainID                 uint64         `json:"chain_id"`
+	AftermarketContractAddr common.Address `json:"aftermarket_contract_addr"`
+	VehicleContractAddr     common.Address `json:"vehicle_contract_addr"`
+}
+
+// isKam reports whether a ds belongs to the Kamaleon family.
+func isKam(ds string) bool { return strings.HasPrefix(ds, kamDSPrefix) }
+
+// ruptelaModule builds a ruptela module configured identically to this one, for
+// delegating the "r/" family.
+func (m Module) ruptelaModule() *ruptela.Module {
+	return &ruptela.Module{
+		ChainID:                 m.ChainID,
+		AftermarketContractAddr: m.AftermarketContractAddr,
+		VehicleContractAddr:     m.VehicleContractAddr,
+	}
+}
+
+// kamEnvelope is the subset of the Kamaleon ingest envelope needed to build the
+// CloudEvent header. It matches the oracle's KamEvent (and the ruptela envelope).
+type kamEnvelope struct {
+	DS             string          `json:"ds"`
+	Signature      string          `json:"signature"`
+	Time           time.Time       `json:"time"`
+	Data           json.RawMessage `json:"data"`
+	VehicleTokenID *uint32         `json:"vehicleTokenId"`
+	DeviceTokenID  *uint32         `json:"deviceTokenId"`
+}
+
+// CloudEventConvert builds the CloudEvent header(s) for an event. The Kamaleon
+// family becomes a single status event whose producer is the synthetic device DID
+// and subject is the vehicle DID; the "r/" family is delegated to the ruptela
+// module unchanged.
+func (m Module) CloudEventConvert(ctx context.Context, msgData []byte) ([]cloudevent.CloudEventHeader, []byte, error) {
+	if !isKam(peekDS(msgData)) {
+		return m.ruptelaModule().CloudEventConvert(ctx, msgData)
+	}
+
+	var event kamEnvelope
+	if err := json.Unmarshal(msgData, &event); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal kamaleon event: %w", err)
+	}
+	if event.DeviceTokenID == nil {
+		return nil, nil, fmt.Errorf("device token id is missing")
+	}
+
+	producer := cloudevent.ERC721DID{
+		ChainID:         m.ChainID,
+		ContractAddress: m.AftermarketContractAddr,
+		TokenID:         big.NewInt(int64(*event.DeviceTokenID)),
+	}.String()
+	subject := producer
+	if event.VehicleTokenID != nil {
+		subject = cloudevent.ERC721DID{
+			ChainID:         m.ChainID,
+			ContractAddress: m.VehicleContractAddr,
+			TokenID:         big.NewInt(int64(*event.VehicleTokenID)),
+		}.String()
+	}
+
+	hdr := cloudevent.CloudEventHeader{
+		DataContentType: "application/json",
+		ID:              ksuid.New().String(),
+		Subject:         subject,
+		SpecVersion:     "1.0",
+		Time:            event.Time,
+		Type:            cloudevent.TypeStatus,
+		DataVersion:     event.DS,
+		Producer:        producer,
+		Signature:       event.Signature,
+	}
+	return []cloudevent.CloudEventHeader{hdr}, event.Data, nil
+}
+
+// SignalConvert decodes signals: Kamaleon events carry pre-decoded VSS signals
+// (default module); ruptela events use the ruptela decoder.
+func (m Module) SignalConvert(ctx context.Context, event cloudevent.RawEvent) ([]vss.Signal, error) {
+	if isKam(event.DataVersion) {
+		return defaultMod.SignalConvert(ctx, event)
+	}
+	return m.ruptelaModule().SignalConvert(ctx, event)
+}
+
+// FingerprintConvert routes to the default module for the Kamaleon family and to
+// ruptela otherwise.
+func (m Module) FingerprintConvert(ctx context.Context, event cloudevent.RawEvent) (modelce.Fingerprint, error) {
+	if isKam(event.DataVersion) {
+		return defaultMod.FingerprintConvert(ctx, event)
+	}
+	return m.ruptelaModule().FingerprintConvert(ctx, event)
+}
+
+// EventConvert routes to the default module for the Kamaleon family and to
+// ruptela otherwise.
+func (m Module) EventConvert(ctx context.Context, event cloudevent.RawEvent) ([]vss.Event, error) {
+	if isKam(event.DataVersion) {
+		return defaultMod.EventConvert(ctx, event)
+	}
+	return m.ruptelaModule().EventConvert(ctx, event)
+}
+
+// peekDS extracts just the ds field without fully decoding the envelope.
+func peekDS(msgData []byte) string {
+	var env struct {
+		DS string `json:"ds"`
+	}
+	_ = json.Unmarshal(msgData, &env)
+	return env.DS
+}

--- a/pkg/kaufmann/module_test.go
+++ b/pkg/kaufmann/module_test.go
@@ -1,0 +1,98 @@
+package kaufmann
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/DIMO-Network/cloudevent"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testChainID   = uint64(137)
+	testSynthAddr = common.HexToAddress("0x4804e8D1661cd1a1e5dDdE1ff458A7f878c0aC6D")
+	testVehAddr   = common.HexToAddress("0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF")
+)
+
+func testModule() Module {
+	return Module{ChainID: testChainID, AftermarketContractAddr: testSynthAddr, VehicleContractAddr: testVehAddr}
+}
+
+func did(addr common.Address, tokenID int64) string {
+	return cloudevent.ERC721DID{ChainID: testChainID, ContractAddress: addr, TokenID: big.NewInt(tokenID)}.String()
+}
+
+// TestCloudEventConvert_Kamaleon verifies a kam/ event becomes a single status
+// event with producer = synthetic device DID, subject = vehicle DID, and the data
+// passed through untouched.
+func TestCloudEventConvert_Kamaleon(t *testing.T) {
+	msg := []byte(`{"ds":"kam/v0/s","time":"2026-07-23T19:34:31Z","data":{"signals":[{"timestamp":"2026-07-23T19:34:31Z","name":"speed","value":42}]},"deviceTokenId":789,"vehicleTokenId":456}`)
+
+	hdrs, data, err := testModule().CloudEventConvert(context.Background(), msg)
+	require.NoError(t, err)
+	require.Len(t, hdrs, 1)
+
+	h := hdrs[0]
+	assert.Equal(t, cloudevent.TypeStatus, h.Type)
+	assert.Equal(t, "kam/v0/s", h.DataVersion)
+	assert.Equal(t, did(testSynthAddr, 789), h.Producer)
+	assert.Equal(t, did(testVehAddr, 456), h.Subject)
+	assert.JSONEq(t, `{"signals":[{"timestamp":"2026-07-23T19:34:31Z","name":"speed","value":42}]}`, string(data))
+}
+
+// TestCloudEventConvert_KamaleonNoVehicleToken falls back to the producer as
+// subject when no vehicle token id is present.
+func TestCloudEventConvert_KamaleonNoVehicleToken(t *testing.T) {
+	msg := []byte(`{"ds":"kam/v0/s","time":"2026-07-23T19:34:31Z","data":{"signals":[]},"deviceTokenId":789}`)
+
+	hdrs, _, err := testModule().CloudEventConvert(context.Background(), msg)
+	require.NoError(t, err)
+	require.Len(t, hdrs, 1)
+	assert.Equal(t, did(testSynthAddr, 789), hdrs[0].Producer)
+	assert.Equal(t, hdrs[0].Producer, hdrs[0].Subject)
+}
+
+// TestCloudEventConvert_KamaleonMissingDeviceToken errors, matching ruptela.
+func TestCloudEventConvert_KamaleonMissingDeviceToken(t *testing.T) {
+	msg := []byte(`{"ds":"kam/v0/s","time":"2026-07-23T19:34:31Z","data":{"signals":[]}}`)
+	_, _, err := testModule().CloudEventConvert(context.Background(), msg)
+	require.Error(t, err)
+}
+
+// TestSignalConvert_Kamaleon decodes the pre-VSS payload via the default module.
+func TestSignalConvert_Kamaleon(t *testing.T) {
+	raw := cloudevent.RawEvent{
+		CloudEventHeader: cloudevent.CloudEventHeader{DataVersion: "kam/v0/s", Type: cloudevent.TypeStatus},
+		Data:             json.RawMessage(`{"signals":[{"timestamp":"2026-07-23T19:34:31Z","name":"speed","value":42}]}`),
+	}
+
+	sigs, err := testModule().SignalConvert(context.Background(), raw)
+	require.NoError(t, err)
+	require.Len(t, sigs, 1)
+	assert.Equal(t, "speed", sigs[0].Data.Name)
+	assert.Equal(t, float64(42), sigs[0].Data.ValueNumber)
+}
+
+// TestCloudEventConvert_RuptelaDelegates verifies the "r/" family still goes
+// through the ruptela module (subject = vehicle DID for a status event),
+// unchanged by this module.
+func TestCloudEventConvert_RuptelaDelegates(t *testing.T) {
+	msg := []byte(`{"ds":"r/v0/s","time":"2026-07-23T19:34:31Z","data":{"signals":{}},"deviceTokenId":789,"vehicleTokenId":456}`)
+
+	hdrs, _, err := testModule().CloudEventConvert(context.Background(), msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, hdrs)
+	assert.Equal(t, "r/v0/s", hdrs[0].DataVersion)
+	assert.Equal(t, did(testVehAddr, 456), hdrs[0].Subject)
+	assert.Equal(t, did(testSynthAddr, 789), hdrs[0].Producer)
+}
+
+func TestIsKam(t *testing.T) {
+	assert.True(t, isKam("kam/v0/s"))
+	assert.False(t, isKam("r/v0/s"))
+	assert.False(t, isKam(""))
+}

--- a/pkg/modules/register.go
+++ b/pkg/modules/register.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DIMO-Network/model-garage/pkg/autopi"
 	"github.com/DIMO-Network/model-garage/pkg/defaultmodule"
 	"github.com/DIMO-Network/model-garage/pkg/hashdog"
+	"github.com/DIMO-Network/model-garage/pkg/kaufmann"
 	"github.com/DIMO-Network/model-garage/pkg/ruptela"
 	"github.com/DIMO-Network/model-garage/pkg/tesla"
 	"github.com/ethereum/go-ethereum/common"
@@ -68,11 +69,16 @@ func RegisterDefaultModules(
 	fingerprintReg.Override(RuptelaSource.String(), ruptelaModule)
 	eventReg.Override(RuptelaSource.String(), ruptelaModule)
 
-	// Kaufmann
-	signalReg.Override(KaufmannSource.String(), ruptelaModule)
-	cloudEventReg.Override(KaufmannSource.String(), ruptelaModule)
-	fingerprintReg.Override(KaufmannSource.String(), ruptelaModule)
-	eventReg.Override(KaufmannSource.String(), ruptelaModule)
+	// Kaufmann — routes the "r/" family to ruptela and the "kam/" (Kamaleon)
+	// family to the default module, by ds. DIS overrides the CloudEvent
+	// registration with a contract-configured instance (see
+	// cloudeventconvert.go); the zero-value module here suffices for the
+	// signal/event/fingerprint registries, which don't build DIDs.
+	kaufmannModule := &kaufmann.Module{}
+	signalReg.Override(KaufmannSource.String(), kaufmannModule)
+	cloudEventReg.Override(KaufmannSource.String(), kaufmannModule)
+	fingerprintReg.Override(KaufmannSource.String(), kaufmannModule)
+	eventReg.Override(KaufmannSource.String(), kaufmannModule)
 
 	// HashDog
 	hashDogModule := &hashdog.Module{}


### PR DESCRIPTION
## Description
Adds a `kaufmann` module that routes the Kaufmann connection source by CloudEvent `ds`, so a single connection license can carry both Ruptela and Queclink/Kamaleon telemetry:

- **`r/...`** — Ruptela Smart5 telemetry (numeric IO-id signals) → **ruptela** module (unchanged historical behavior).
- **`kam/...`** — Queclink/Kamaleon telemetry that the Kaufmann oracle has already decoded into VSS-named signals → **default** module.

CloudEvent headers are built identically for both families (producer = synthetic device DID, subject = vehicle DID, from the envelope's `deviceTokenId`/`vehicleTokenId`); only signal/event/fingerprint decoding forks on the `ds` prefix.

### Context
The Kaufmann oracle (kaufmann-oracle) now ingests Queclink GV58/GV300W devices carrying Kamaleon telemetry via a flespi proxy and pre-decodes them to VSS signals, emitting a `kam/v0/s` envelope alongside its existing `r/v0/*` ruptela events. Previously `KaufmannSource` was mapped straight to the ruptela module, which cannot parse Kamaleon payloads. See the oracle-side change (kaufmann-oracle#164) and its wire-contract doc.

### Changes
- `pkg/kaufmann/module.go`: new `Module` implementing CloudEvent/Signal/Fingerprint/Event interfaces with ds-based routing to `ruptela` / `defaultmodule`.
- `pkg/modules/register.go`: map `KaufmannSource` to `kaufmann.Module` instead of `ruptela.Module`.
- Tests: kam/ header construction (producer/subject DIDs, data passthrough), kam/ signal decode via default module, and an `r/` **delegation regression** confirming existing ruptela behavior is unchanged.

### Downstream (separate PR)
DIS's `newCloudConvertProcessor` should override the `CloudEventRegistry` for `KaufmannSource` with a contract-configured `kaufmann.Module{AftermarketContractAddr: syntheticAddr, VehicleContractAddr: vehicleAddr, ChainID: chainID}`, replacing the current `ruptelaSyntheticModule` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
